### PR TITLE
File enhancements

### DIFF
--- a/src/config.cljs
+++ b/src/config.cljs
@@ -12,7 +12,7 @@
 
 (def default-path "documents")
 
-(def save-excluded-keys [:id :title :path :file-handle])
+(def save-info-keys [:id :title :path]) ; Should not be saved to disk.
 
 (def sentry {:dsn "https://4098ce3035c6f04b92b636bda55790ac@o4510040121933824.ingest.de.sentry.io/4510040141201488"
              :environment (if debug? "development" "production")

--- a/src/electron/file.cljs
+++ b/src/electron/file.cljs
@@ -1,4 +1,6 @@
 (ns electron.file
+  "File operations using Electron APIs.
+   The end goal is to eventually replace this with the File System Access API."
   (:require
    ["electron" :refer [app dialog BrowserWindow]]
    ["fs" :as fs]
@@ -20,7 +22,7 @@
 
 (defn write-file!
   [file-path data]
-  (let [document (-> (apply dissoc data config/save-excluded-keys)
+  (let [document (-> (apply dissoc data config/save-info-keys)
                      (pr-str))]
     (-> (.writeFile fs/promises file-path document "utf-8")
         (.then #(-> (select-keys data [:id])

--- a/src/renderer/app/db.cljs
+++ b/src/renderer/app/db.cljs
@@ -5,7 +5,7 @@
    [malli.transform :as m.transform]
    [renderer.db :refer [JS_Object]]
    [renderer.dialog.db :refer [Dialog]]
-   [renderer.document.db :refer [Document]]
+   [renderer.document.db :refer [Document SaveInfo]]
    [renderer.element.db :refer [Element]]
    [renderer.frame.db :refer [DomRect]]
    [renderer.notification.db :refer [Notification]]
@@ -72,7 +72,7 @@
                     :persist true} [:vector uuid?]]
    [:recent {:max 10
              :default []
-             :persist true} [:vector string?]]
+             :persist true} [:vector SaveInfo]]
    [:drag-threshold {:default 1} number?]
    [:system-fonts {:optional true} SystemFonts]
    [:notifications {:default []} [:* Notification]]
@@ -120,10 +120,9 @@
 
 (def explain (m/explainer App))
 
-(def default
-  (m/decode App
-            {:version config/version}
-            m.transform/default-value-transformer))
+(def default (m/decode App
+                       {:version config/version}
+                       m.transform/default-value-transformer))
 
 (def persisted-keys
   "Top level keys that should be persisted to local storage."

--- a/src/renderer/app/views.cljs
+++ b/src/renderer/app/views.cljs
@@ -3,7 +3,7 @@
    ["@radix-ui/react-direction" :as Direction]
    ["@radix-ui/react-select" :as Select]
    ["@radix-ui/react-tooltip" :as Tooltip]
-   ["path-browserify" :as path]
+   ["path-browserify" :as path-browserify]
    ["react-fps" :refer [FpsView]]
    ["react-resizable-panels" :refer [Panel PanelGroup]]
    [clojure.string :as string]
@@ -269,13 +269,14 @@
           [:> Select/ItemText (str "A" k)]])]]]]])
 
 (defn recent-document
-  [file-path]
+  [{:keys [path title]
+    :as recent}]
   [:div.flex.items-center.gap-x-2.flex-wrap
    [views/icon "folder"]
    [:button.button-link.text-lg
-    {:on-click #(rf/dispatch [::document.events/open file-path])}
-    (.basename path file-path)]
-   [:span.text-lg.text-muted (.dirname path file-path)]])
+    {:on-click #(rf/dispatch [::document.events/open-recent recent])}
+    (or title (.basename path-browserify path))]
+   (when path [:span.text-lg.text-muted (.dirname path-browserify path)])])
 
 (defn help-command
   [icon label event]
@@ -320,17 +321,17 @@
          [:div.flex.items-center.gap-2
           [views/icon "folder"]
           [:button.button-link.text-lg
-           {:on-click #(rf/dispatch [::document.events/open nil])}
+           {:on-click #(rf/dispatch [::document.events/open])}
            (t [::open "Open"])]
-          [views/shortcuts [::document.events/open nil]]]
+          [views/shortcuts [::document.events/open]]]
 
          (when (seq recent-documents)
            [:<> [:h2.mb-3.mt-8.text-2xl
                  (t [::recent "Recent"])]
 
-            (for [file-path (take 5 recent-documents)]
-              ^{:key file-path}
-              [recent-document file-path])])
+            (for [recent (take 5 recent-documents)]
+              ^{:key (:id recent)}
+              [recent-document recent])])
 
          [:h2.mb-3.mt-8.text-2xl
           (t [::help "Help"])]

--- a/src/renderer/document/db.cljs
+++ b/src/renderer/document/db.cljs
@@ -19,7 +19,7 @@
             :min 1
             :persist true} string?]
    [:path {:optional true
-           :persist true} [:maybe string?]]
+           :persist true} string?]
    [:saved-history-id {:optional true} uuid?]
    [:version {:optional true
               :persist true} string?]
@@ -36,8 +36,7 @@
    [:filter {:optional true} A11yFilter]
    [:attrs {:default {:fill "white"
                       :stroke "black"}} [:map-of keyword? string?]]
-   [:preview-label {:optional true} string?]
-   [:file-handle {:optional true} any?]])
+   [:preview-label {:optional true} string?]])
 
 (def PersistedDocument
   (->> Document
@@ -48,11 +47,13 @@
 (def SaveInfo
   (->> Document
        (m/children)
-       (filter (comp #(some #{%} config/save-excluded-keys) first))
+       (filter (comp #(some #{%} config/save-info-keys) first))
        (into [:map {:closed true}])))
 
 (def valid? (m/validator Document))
 
 (def explain (m/explainer Document))
 
-(def default (m/decode Document {} m.transform/default-value-transformer))
+(def default (m/decode Document
+                       {}
+                       m.transform/default-value-transformer))

--- a/src/renderer/element/events.cljs
+++ b/src/renderer/element/events.cljs
@@ -357,4 +357,4 @@
        :else
        (let [extension (last (string/split (.-name file) "."))]
          (when (= extension "rps")
-           {:dispatch [::document.events/file-read file]}))))))
+           {:dispatch [::document.events/file-read nil file]}))))))

--- a/src/renderer/event/impl/keyboard.cljs
+++ b/src/renderer/event/impl/keyboard.cljs
@@ -207,10 +207,10 @@
                 [[::window.events/close]
                  [{:keyCode (key-codes "Q")
                    :ctrlKey true}]]
-                [[::document.events/open nil]
+                [[::document.events/open]
                  [{:keyCode (key-codes "O")
                    :ctrlKey true}]]
-                [[::document.events/save {:as true}]
+                [[::document.events/save-as]
                  [{:keyCode (key-codes "S")
                    :ctrlKey true
                    :shiftKey true}]]

--- a/src/renderer/events.cljs
+++ b/src/renderer/events.cljs
@@ -24,6 +24,11 @@
    {::effects/file-open options}))
 
 (rf/reg-event-fx
+ ::file-save
+ (fn [_ [_ options]]
+   {::effects/file-save options}))
+
+(rf/reg-event-fx
  ::open-remote-url
  (fn [{:keys [db]} [_ url]]
    (if (= (:platform db) "web")

--- a/src/renderer/history/handlers.cljs
+++ b/src/renderer/history/handlers.cljs
@@ -72,6 +72,8 @@
                  [:-> App App]
                  [:-> App uuid? App]])
 (defn drop-rest
+  "Drops all but the current state from history.
+   Useful to avoid persisting the rest if the history."
   ([db]
    (reduce drop-rest db (:document-tabs db)))
   ([db document-id]

--- a/src/renderer/menubar/views.cljs
+++ b/src/renderer/menubar/views.cljs
@@ -26,12 +26,15 @@
 
 (defn recent-submenu
   []
-  (let [recent @(rf/subscribe [::document.subs/recent])
-        recent-items (mapv (fn [path]
-                             {:id (keyword path)
-                              :label path
-                              :icon "folder"
-                              :action [::document.events/open path]}) recent)]
+  (let [recent-documents @(rf/subscribe [::document.subs/recent])
+        recent-items (->> recent-documents
+                          (mapv (fn [{:keys [path title id]
+                                      :as recent}]
+                                  {:id id
+                                   :label (or path title)
+                                   :icon "folder"
+                                   :action [::document.events/open-recent
+                                            recent]})))]
     (cond-> recent-items
       (seq recent-items)
       (concat [{:id :divider-1
@@ -85,7 +88,7 @@
            {:id :open-file
             :label (t [::open "Open..."])
             :icon "folder"
-            :action [::document.events/open nil]}
+            :action [::document.events/open]}
            {:id :recent
             :label (t [::recent "Recent"])
             :type :sub-menu
@@ -108,7 +111,7 @@
            {:id :save-as
             :label (t [::save-as "Save as..."])
             :icon "save-as"
-            :action [::document.events/save {:as true}]
+            :action [::document.events/save-as]
             :disabled (not @(rf/subscribe [::document.subs/entities?]))}
            {:id :export
             :label (t [::export-as "Export as"])

--- a/src/renderer/window/events.cljs
+++ b/src/renderer/window/events.cljs
@@ -52,7 +52,7 @@
 (rf/reg-event-fx
  ::clear-data-and-relaunch
  (fn [_ _]
-   {:fx [[::app.effects/clear-local-storage nil]
+   {:fx [[::app.effects/clear-local-store nil]
          [:dispatch [::relaunch]]]}))
 
 (rf/reg-event-fx

--- a/test/document_test.cljs
+++ b/test/document_test.cljs
@@ -152,14 +152,21 @@
        (let [recent-documents (rf/subscribe [::document.subs/recent])]
          (rf/dispatch [::document.events/load-multiple
                        [{:version "100000.0.0"
+                         :id #uuid "58c1f2bb-94ea-4b95-b042-c42121384b9a"
                          :path "foo/bar/document-1.rps"
                          :title "document-1.rps"
                          :elements {}}
                         {:version "100000.0.0"
+                         :id #uuid "01eafc60-3ce3-41d2-a138-1fe1759ad4f2"
                          :path "foo/bar/document-2.rps"
                          :title "document-2.rps"
                          :elements {}}]])
 
          (is (= (:title @active-document) "document-2.rps"))
-         (is (= (take 2 @recent-documents) ["foo/bar/document-2.rps"
-                                            "foo/bar/document-1.rps"])))))))
+         (is (= (take 2 @recent-documents)
+                [{:id #uuid "01eafc60-3ce3-41d2-a138-1fe1759ad4f2"
+                  :title "document-2.rps"
+                  :path "foo/bar/document-2.rps"}
+                 {:id #uuid "58c1f2bb-94ea-4b95-b042-c42121384b9a"
+                  :title "document-1.rps"
+                  :path "foo/bar/document-1.rps"}])))))))

--- a/test/fixtures.cljs
+++ b/test/fixtures.cljs
@@ -8,7 +8,10 @@
    [renderer.theme.effects :as-alias theme.effects]
    [renderer.window.effects :as-alias window.effects]))
 
-(def local-store {config/app-name {}})
+(def local-store
+  (atom {config/app-name {:error-reporting false
+                          :recent [{:id #uuid "123e4567-e89b-12d3-a456-426614174000"
+                                    :title "drawing-1.rps"}]}}))
 
 (defn test-fixtures
   []
@@ -19,8 +22,28 @@
   (rf/reg-fx
    ::app.effects/get-local-store
    (fn [{:keys [store-key on-success on-finally]}]
-     (some-> on-success (conj (get local-store store-key)) rf/dispatch)
+     (some-> on-success (conj (get @local-store store-key)) rf/dispatch)
      (some-> on-finally rf/dispatch)))
+
+  (rf/reg-fx
+   ::app.effects/set-local-store
+   (fn [{:keys [store-key data on-success]}]
+     (swap! local-store assoc store-key data)
+     (some-> on-success (conj data) rf/dispatch)))
+
+  (rf/reg-fx
+   ::app.effects/local-store-keys
+   (fn [{:keys [on-success]}]
+     (some-> on-success (conj (keys @local-store)) rf/dispatch)))
+
+  (rf/reg-fx
+   ::app.effects/remove-local-store
+   (fn [{:keys [store-key]}]
+     (swap! local-store dissoc store-key)))
+
+  (rf/reg-fx
+   ::app.effects/persist
+   (fn []))
 
   (rf/reg-cofx
    ::window.effects/fullscreen


### PR DESCRIPTION
We now persist document file handles on indexedDB and use them to open recent and save open files on future sessions, without having to pick a file. That was preciously available on the desktop app only, by using the path. We are now also one step closer to removing the electron file namespace in favor of the File System Access API.