### PR TITLE
Avoid opening document duplicates on web by checking the handle

### DIFF
--- a/src/config.cljs
+++ b/src/config.cljs
@@ -12,7 +12,7 @@
 
 (def default-path "documents")
 
-(def save-info-keys [:id :title :path]) ; Should not be saved to disk.
+(def save-info-keys [:id :title :path :file-handle])
 
 (def sentry {:dsn "https://4098ce3035c6f04b92b636bda55790ac@o4510040121933824.ingest.de.sentry.io/4510040141201488"
              :environment (if debug? "development" "production")

--- a/src/renderer/app/db.cljs
+++ b/src/renderer/app/db.cljs
@@ -5,7 +5,7 @@
    [malli.transform :as m.transform]
    [renderer.db :refer [BBox Vec2 JS_Object]]
    [renderer.dialog.db :refer [Dialog]]
-   [renderer.document.db :refer [Document DocumentId SaveInfo]]
+   [renderer.document.db :refer [Document DocumentId RecentDocument]]
    [renderer.element.db :refer [Element]]
    [renderer.frame.db :refer [DomRect]]
    [renderer.ruler.db :refer [Ruler]]
@@ -69,7 +69,7 @@
                     :persist true} [:vector DocumentId]]
    [:recent {:max 10
              :default []
-             :persist true} [:vector SaveInfo]]
+             :persist true} [:vector RecentDocument]]
    [:drag-threshold {:default 1} number?]
    [:system-fonts {:optional true} SystemFonts]
    [:debug-info {:default false} boolean?]

--- a/src/renderer/core.cljs
+++ b/src/renderer/core.cljs
@@ -12,6 +12,7 @@
    [renderer.attribute.impl.core]
    [renderer.dialog.events]
    [renderer.dialog.subs]
+   [renderer.document.effects]
    [renderer.document.events]
    [renderer.document.subs]
    [renderer.element.effects]

--- a/src/renderer/document/effects.cljs
+++ b/src/renderer/document/effects.cljs
@@ -1,0 +1,31 @@
+(ns renderer.document.effects
+  (:require
+   ["localforage" :as localforage]
+   [config :as config]
+   [re-frame.core :as rf]))
+
+(defn- find-same-entry
+  [ks file-handle]
+  (->> ks
+       (remove #(= % config/app-name))
+       (map #(vector % (localforage/getItem %)))
+       (map (fn [[id promise]]
+              (-> promise
+                  (.then (fn [handle]
+                           (some-> handle
+                                   (.isSameEntry file-handle)
+                                   (.then #(when %
+                                             (uuid id)))))))))))
+
+(rf/reg-fx
+ ::query-file-handle
+ (fn [{:keys [file-handle on-found on-not-found on-error]}]
+   (-> (localforage/keys)
+       (.then (fn [ks]
+                (-> (find-same-entry ks file-handle)
+                    (js/Promise.all)
+                    (.then #(if-let [open-id (->> (remove nil? %)
+                                                  (first))]
+                              (some-> on-found (conj open-id) rf/dispatch)
+                              (some-> on-not-found rf/dispatch)))
+                    (.catch #(some-> on-error (conj %) rf/dispatch))))))))

--- a/src/renderer/utils/migration.cljs
+++ b/src/renderer/utils/migration.cljs
@@ -59,4 +59,7 @@
    [[0 4 6] (fn [document]
               (update document :elements update-vals
                       (fn [el]
-                        (update-keys el #(if (= :bounds %) :bbox %)))))]])
+                        (update-keys el #(if (= :bounds %) :bbox %)))))]
+
+   [[0 4 10] (fn [document]
+               (dissoc document :save))]])


### PR DESCRIPTION
We now use [isSameEntry](https://developer.mozilla.org/en-US/docs/Web/API/FileSystemHandle/isSameEntry) to check if we already have an associated [FileSystemHandle](https://developer.mozilla.org/en-US/docs/Web/API/FileSystemHandle) to avoid opening the same document twice, and also avoid recent document duplicates.