### PR TITLE
Simplify history model

### DIFF
--- a/src/renderer/document/db.cljs
+++ b/src/renderer/document/db.cljs
@@ -5,7 +5,7 @@
    [renderer.db :refer [Vec2 JS_Object]]
    [renderer.element.db :refer [Element ElementId]]
    [renderer.filters :refer [A11yFilter]]
-   [renderer.history.db :refer [History HistoryId]]
+   [renderer.history.db :refer [History HistoryIndex]]
    [renderer.tool.db :refer [HandleId]]))
 
 (def ZoomFactor
@@ -20,7 +20,7 @@
    [:id {:optional true} DocumentId]
    [:title {:optional true} DocumentTitle]
    [:path {:optional true} string?]
-   [:saved-history-id {:optional true} HistoryId]
+   [:saved-history-id {:optional true} HistoryIndex]
    [:version {:optional true} string?]
    [:hovered-ids {:default #{}} [:set [:or HandleId ElementId]]]
    [:collapsed-ids {:default #{}} [:set ElementId]]

--- a/src/renderer/history/db.cljs
+++ b/src/renderer/history/db.cljs
@@ -5,8 +5,6 @@
 
 (def Explanation [:* any?])
 
-(def HistoryId uuid?)
-
 (def HistoryIndex [:or pos-int? zero?])
 
 (def HistoryState
@@ -14,14 +12,13 @@
    [:explanation Explanation]
    [:timestamp number?]
    [:index HistoryIndex]
-   [:id HistoryId]
    [:elements {:optional true} [:map-of ElementId Element]]
-   [:parent {:optional true} HistoryId]
-   [:children [:vector HistoryId]]])
+   [:parent {:optional true} HistoryIndex]
+   [:children [:vector HistoryIndex]]])
 
 (def History
   [:map {:closed true}
    [:zoom {:optional true} number?]
    [:translate {:optional true} Vec2]
-   [:position {:optional true} HistoryId]
-   [:states {:default {}} [:map-of uuid? HistoryState]]])
+   [:position {:optional true} HistoryIndex]
+   [:states {:default {}} [:map-of HistoryIndex HistoryState]]])

--- a/src/renderer/history/subs.cljs
+++ b/src/renderer/history/subs.cljs
@@ -43,5 +43,4 @@
  :<- [::history]
  :<- [::document.subs/saved-history-id]
  (fn [[history saved-history-id] _]
-   (let [root-id (history.handlers/root-id history)]
-     (history.handlers/state->d3-data history root-id saved-history-id))))
+   (history.handlers/state->d3-data history saved-history-id)))

--- a/src/renderer/history/views.cljs
+++ b/src/renderer/history/views.cljs
@@ -13,16 +13,16 @@
    [renderer.views :as views]))
 
 (defn select-option
-  [{:keys [id explanation]}]
+  [{:keys [index explanation]}]
   [:> Select/Item
-   {:value (str id)
+   {:value index
     :class "menu-item px-2!"}
    [:> Select/ItemText (apply t explanation)]])
 
 (defn select
   [label options open]
   [:> Select/Root
-   {:on-value-change #(rf/dispatch [::history.events/go-to (uuid %)])
+   {:on-value-change #(rf/dispatch [::history.events/go-to %])
     :on-open-change #(reset! open %)
     :disabled (empty? options)}
    [:> Select/Trigger
@@ -72,7 +72,7 @@
   [^js/CustomNodeElementProps props]
   (let [datum (.-nodeDatum props)
         active? (.-active datum)
-        id (uuid (.-id datum))
+        id (.-id datum)
         color (if active? "var(--color-accent)" (.-color datum))]
     (reagent/as-element
      [:circle.transition-fill


### PR DESCRIPTION
The `uuid` of each history state is not actually needed. We can use the history index as a unique identifier. That removes the side effect when we create a new state and it simplifies the model. `root-id` function is removed, since we can now simply use `0`. `state->d3-data` was also modified to use tail call optimization to avoid exceeding the maximum call stack.