### PR TITLE
Introduce a11y filter registry

### DIFF
--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -45,7 +45,7 @@
 
                    :devtools {:preloads [devtools.preload
                                          day8.re-frame-10x.preload.react-18
-                                         malli.dev.cljs-kondo-preload
+                                         #_malli.dev.cljs-kondo-preload
                                          dev]}}
 
              :release {:build-options {:ns-aliases

--- a/src/lang/ar-EG.edn
+++ b/src/lang/ar-EG.edn
@@ -145,7 +145,7 @@
   :report-errors "الإبلاغ عن الأخطاء تلقائياً"
   :about "حول"}
 
- :renderer.filters
+ :renderer.a11y.db
  {:blur "ضبابية البصر"
   :blur-x2 "ضبابية البصر المضاعفة"
   :protanopia "عمى الألوان الأحمر"

--- a/src/lang/de-DE.edn
+++ b/src/lang/de-DE.edn
@@ -145,7 +145,7 @@
   :report-errors "Fehler automatisch melden"
   :about "Über"}
 
- :renderer.filters
+ :renderer.a11y.db
  {:blur "Unschärfe"
   :blur-x2 "Starke Unschärfe"
   :protanopia "Protanopie"

--- a/src/lang/el-GR.edn
+++ b/src/lang/el-GR.edn
@@ -145,7 +145,7 @@
   :report-errors "Αναφορά σφαλμάτων αυτόματα"
   :about "Σχετικά"}
 
- :renderer.filters
+ :renderer.a11y.db
  {:blur "θόλωση όρασης"
   :blur-x2 "έντονη θόλωση όρασης"
   :protanopia "πρωτανωπία"

--- a/src/lang/en-US.edn
+++ b/src/lang/en-US.edn
@@ -145,7 +145,7 @@
   :report-errors "Report errors automatically"
   :about "About"}
 
- :renderer.filters
+ :renderer.a11y.db
  {:blur "blur"
   :blur-x2 "blur-x2"
   :protanopia "protanopia"

--- a/src/lang/es-ES.edn
+++ b/src/lang/es-ES.edn
@@ -145,7 +145,7 @@
   :report-errors "Reportar errores automáticamente"
   :about "Acerca de"}
 
- :renderer.filters
+ :renderer.a11y.db
  {:blur "desenfoque"
   :blur-x2 "desenfoque-x2"
   :protanopia "protanopia"

--- a/src/lang/fr-FR.edn
+++ b/src/lang/fr-FR.edn
@@ -145,7 +145,7 @@
   :report-errors "Signaler les erreurs automatiquement"
   :about "À propos"}
 
- :renderer.filters
+ :renderer.a11y.db
  {:blur "flou"
   :blur-x2 "flou-x2"
   :protanopia "protanopie"

--- a/src/lang/it-IT.edn
+++ b/src/lang/it-IT.edn
@@ -145,7 +145,7 @@
   :report-errors "Segnala errori automaticamente"
   :about "Informazioni"}
 
- :renderer.filters
+ :renderer.a11y.db
  {:blur "sfocatura"
   :blur-x2 "sfocatura-x2"
   :protanopia "protanopia"

--- a/src/lang/ja-JP.edn
+++ b/src/lang/ja-JP.edn
@@ -145,7 +145,7 @@
   :report-errors "エラーを自動的に報告"
   :about "このアプリについて"}
 
- :renderer.filters
+ :renderer.a11y.db
  {:blur "ブラー"
   :blur-x2 "ブラーx2"
   :protanopia "第一色覚異常"

--- a/src/lang/ko-KR.edn
+++ b/src/lang/ko-KR.edn
@@ -145,7 +145,7 @@
   :report-errors "오류 자동 보고"
   :about "정보"}
 
- :renderer.filters
+ :renderer.a11y.db
  {:blur "흐림"
   :blur-x2 "흐림-x2"
   :protanopia "적색맹"

--- a/src/lang/nl-NL.edn
+++ b/src/lang/nl-NL.edn
@@ -145,7 +145,7 @@
   :report-errors "Fouten automatisch melden"
   :about "Over"}
 
- :renderer.filters
+ :renderer.a11y.db
  {:blur "vervaging"
   :blur-x2 "vervaging-x2"
   :protanopia "protanopie"

--- a/src/lang/pt-PT.edn
+++ b/src/lang/pt-PT.edn
@@ -145,7 +145,7 @@
   :report-errors "Reportar erros automaticamente"
   :about "Acerca de"}
 
- :renderer.filters
+ :renderer.a11y.db
  {:blur "desfoque"
   :blur-x2 "desfoque-x2"
   :protanopia "protanopia"

--- a/src/lang/ru-RU.edn
+++ b/src/lang/ru-RU.edn
@@ -145,7 +145,7 @@
   :report-errors "Сообщать об ошибках автоматически"
   :about "О программе"}
 
- :renderer.filters
+ :renderer.a11y.db
  {:blur "размытие"
   :blur-x2 "размытие-x2"
   :protanopia "протанопия"

--- a/src/lang/sv-SE.edn
+++ b/src/lang/sv-SE.edn
@@ -145,7 +145,7 @@
   :report-errors "Rapportera fel automatiskt"
   :about "Om"}
 
- :renderer.filters
+ :renderer.a11y.db
  {:blur "suddig"
   :blur-x2 "suddig-x2"
   :protanopia "protanopi"

--- a/src/lang/tr-TR.edn
+++ b/src/lang/tr-TR.edn
@@ -145,7 +145,7 @@
   :report-errors "Hataları otomatik olarak bildir"
   :about "Hakkında"}
 
- :renderer.filters
+ :renderer.a11y.db
  {:blur "bulanık"
   :blur-x2 "bulanık-x2"
   :protanopia "protanopi"

--- a/src/lang/zh-CN.edn
+++ b/src/lang/zh-CN.edn
@@ -144,7 +144,7 @@
   :report-errors "自动报告错误"
   :about "关于"}
 
- :renderer.filters
+ :renderer.a11y.db
  {:blur "模糊"
   :blur-x2 "模糊-x2"
   :protanopia "红色盲"

--- a/src/renderer/a11y/db.cljs
+++ b/src/renderer/a11y/db.cljs
@@ -1,27 +1,57 @@
-(ns renderer.filters
+(ns renderer.a11y.db
   (:require
-   [renderer.utils.i18n :refer [t]]))
+   [renderer.utils.i18n :refer [Translation]]))
 
-(defn accessibility
-  []
+(def A11yFilterId keyword?)
+
+(def FilterTag
+  [:enum
+   :feSpotLight
+   :feBlend
+   :feColorMatrix
+   :feComponentTransfer
+   :feComposite
+   :feConvolveMatrix
+   :feDiffuseLighting
+   :feDisplacementMap
+   :feDropShadow
+   :feFlood
+   :feGaussianBlur
+   :feImage
+   :feMerge
+   :feMorphology
+   :feOffset
+   :feSpecularLighting
+   :feTile
+   :feTurbulence])
+
+(def A11yFilter
+  [:map {:closed true}
+   [:id A11yFilterId]
+   [:tag FilterTag]
+   [:label Translation]
+   [:attrs {:default {}} [:map-of keyword? any?]]])
+
+(def default
   [{:id :blur
     :tag :feGaussianBlur
-    :label (t [::blur "blur"])
+    :label [[::blur "blur"]]
     :attrs {:in "SourceGraphic"
             :type "matrix"
             :stdDeviation "1"}}
 
    {:id :blur-x2
     :tag :feGaussianBlur
-    :label (t [::blur-x2 "blur-x2"])
+    :label [[::blur-x2 "blur-x2"]]
     :attrs {:in "SourceGraphic"
             :type "matrix"
             :stdDeviation "2"}}
 
    ;; https://github.com/hail2u/color-blindness-emulation
+
    {:id :protanopia
     :tag :feColorMatrix
-    :label (t [::protanopia "protanopia"])
+    :label [[::protanopia "protanopia"]]
     :attrs {:in "SourceGraphic"
             :type "matrix"
             :value [0.567, 0.433, 0, 0, 0
@@ -31,7 +61,7 @@
 
    {:id :protanomaly
     :tag :feColorMatrix
-    :label (t [::protanomaly "protanomaly"])
+    :label [[::protanomaly "protanomaly"]]
     :attrs {:values [0.817, 0.183, 0, 0, 0
                      0.333, 0.667, 0, 0, 0
                      0, 0.125, 0.875, 0, 0
@@ -39,7 +69,7 @@
 
    {:id :deuteranopia
     :tag :feColorMatrix
-    :label (t [::deuteranopia "deuteranopia"])
+    :label [[::deuteranopia "deuteranopia"]]
     :attrs {:values [0.625, 0.375, 0, 0, 0
                      0.7, 0.3, 0, 0, 0
                      0, 0.3, 0.7, 0, 0
@@ -47,7 +77,7 @@
 
    {:id :deuteranomaly
     :tag :feColorMatrix
-    :label (t [::deuteranomaly "deuteranomaly"])
+    :label [[::deuteranomaly "deuteranomaly"]]
     :attrs {:values [0.8, 0.2, 0, 0, 0
                      0.258, 0.742, 0, 0, 0
                      0, 0.142, 0.858, 0, 0
@@ -55,7 +85,7 @@
 
    {:id :tritanopia
     :tag :feColorMatrix
-    :label (t [::tritanopia "tritanopia"])
+    :label [[::tritanopia "tritanopia"]]
     :attrs {:values [0.95, 0.05, 0, 0, 0
                      0, 0.433, 0.567, 0, 0
                      0, 0.475, 0.525, 0, 0
@@ -63,7 +93,7 @@
 
    {:id :tritanomaly
     :tag :feColorMatrix
-    :label (t [::tritanomaly "tritanomaly"])
+    :label [[::tritanomaly "tritanomaly"]]
     :attrs {:values [0.967, 0.033, 0, 0, 0
                      0, 0.733, 0.267, 0, 0
                      0, 0.183, 0.817, 0, 0
@@ -71,7 +101,7 @@
 
    {:id :achromatopsia
     :tag :feColorMatrix
-    :label (t [::tritanomaly "tritanomaly"])
+    :label [[::tritanomaly "tritanomaly"]]
     :attrs {:values [0.299, 0.587, 0.114, 0, 0
                      0.299, 0.587, 0.114, 0, 0
                      0.299, 0.587, 0.114, 0, 0
@@ -79,21 +109,8 @@
 
    {:id :achromatomaly
     :tag :feColorMatrix
-    :label (t [::achromatopsia "achromatopsia"])
+    :label [[::achromatopsia "achromatopsia"]]
     :attrs {:values [0.618, 0.320, 0.062, 0, 0
                      0.163, 0.775, 0.062, 0, 0
                      0.163, 0.320, 0.516, 0, 0
                      0, 0, 0, 1, 0]}}])
-
-(def A11yFilter
-  [:enum
-   :blur
-   :blur-x2
-   :protanopia
-   :protanomaly
-   :deuteranopia
-   :deuteranomaly
-   :tritanopia
-   :tritanomaly
-   :achromatopsia
-   :achromatomaly])

--- a/src/renderer/a11y/events.cljs
+++ b/src/renderer/a11y/events.cljs
@@ -1,0 +1,14 @@
+(ns renderer.a11y.events
+  (:require
+   [re-frame.core :as rf]
+   [renderer.a11y.handlers :as handlers]))
+
+(rf/reg-event-db
+ ::register-filter
+ (fn [db [_ a11y-filter]]
+   (handlers/register-filter db a11y-filter)))
+
+(rf/reg-event-db
+ ::deregister-filter
+ (fn [db [_ a11y-filter-id]]
+   (handlers/deregister-filter db a11y-filter-id)))

--- a/src/renderer/a11y/handlers.cljs
+++ b/src/renderer/a11y/handlers.cljs
@@ -4,11 +4,6 @@
    [renderer.a11y.db :refer [A11yFilter A11yFilterId]]
    [renderer.app.db :refer [App]]))
 
-(m/=> register-filter [:-> App A11yFilter App])
-(defn register-filter
-  [db a11y-filter]
-  (update db :a11y-filters conj a11y-filter))
-
 (m/=> deregister-filter [:-> App A11yFilterId App])
 (defn deregister-filter
   [db a11y-filter-id]
@@ -17,3 +12,10 @@
             (->> filters
                  (remove #(= (:id %) a11y-filter-id))
                  (into [])))))
+
+(m/=> register-filter [:-> App A11yFilter App])
+(defn register-filter
+  [db a11y-filter]
+  (-> db
+      (deregister-filter (:id a11y-filter))
+      (update :a11y-filters conj a11y-filter)))

--- a/src/renderer/a11y/handlers.cljs
+++ b/src/renderer/a11y/handlers.cljs
@@ -1,0 +1,17 @@
+(ns renderer.a11y.handlers
+  (:require
+   [malli.core :as m]
+   [renderer.a11y.db :refer [A11yFilter A11yFilterId]]
+   [renderer.app.db :refer [App]]))
+
+(m/=> register-filter [:-> App A11yFilter App])
+(defn register-filter
+  [db a11y-filter]
+  (update db :a11y-filters conj a11y-filter))
+
+(m/=> deregister-filter [:-> App A11yFilterId App])
+(defn deregister-filter
+  [db a11y-filter-id]
+  (update db :a11y-filters
+          (fn [filters]
+            (remove #(= (:id %) a11y-filter-id) filters))))

--- a/src/renderer/a11y/handlers.cljs
+++ b/src/renderer/a11y/handlers.cljs
@@ -14,4 +14,6 @@
   [db a11y-filter-id]
   (update db :a11y-filters
           (fn [filters]
-            (remove #(= (:id %) a11y-filter-id) filters))))
+            (->> filters
+                 (remove #(= (:id %) a11y-filter-id))
+                 (into [])))))

--- a/src/renderer/a11y/subs.cljs
+++ b/src/renderer/a11y/subs.cljs
@@ -1,0 +1,7 @@
+(ns renderer.a11y.subs
+  (:require
+   [re-frame.core :as rf]))
+
+(rf/reg-sub
+ ::filters
+ :-> :a11y-filters)

--- a/src/renderer/app/db.cljs
+++ b/src/renderer/app/db.cljs
@@ -3,6 +3,7 @@
    [config :as config]
    [malli.core :as m]
    [malli.transform :as m.transform]
+   [renderer.a11y.db :as a11y.db :refer [A11yFilter]]
    [renderer.db :refer [BBox Vec2 JS_Object]]
    [renderer.dialog.db :refer [Dialog]]
    [renderer.document.db :refer [Document DocumentId RecentDocument]]
@@ -112,6 +113,7 @@
    [:copied-elements {:optional true} [:* Element]]
    [:kdtree {:optional true} [:maybe map?]]
    [:viewbox-kdtree {:optional true} [:maybe map?]]
+   [:a11y-filters {:default a11y.db/default} [:vector A11yFilter]]
    [:re-pressed.core/keydown {:optional true} map?]])
 
 (def valid? (m/validator App))

--- a/src/renderer/core.cljs
+++ b/src/renderer/core.cljs
@@ -3,6 +3,8 @@
    ["electron-log/renderer"]
    [re-frame.core :as rf]
    [reagent.dom.client :as ra.dom.client]
+   [renderer.a11y.events]
+   [renderer.a11y.subs]
    [renderer.app.effects]
    [renderer.app.events :as app.events]
    [renderer.app.subs]

--- a/src/renderer/document/db.cljs
+++ b/src/renderer/document/db.cljs
@@ -2,9 +2,9 @@
   (:require
    [malli.core :as m]
    [malli.transform :as m.transform]
+   [renderer.a11y.db :refer [A11yFilterId]]
    [renderer.db :refer [Vec2 JS_Object]]
    [renderer.element.db :refer [Element ElementId]]
-   [renderer.filters :refer [A11yFilter]]
    [renderer.history.db :refer [History HistoryIndex]]
    [renderer.tool.db :refer [HandleId]]))
 
@@ -31,7 +31,7 @@
    [:pan {:default [0 0]} Vec2]
    [:elements {:default {}} [:map-of ElementId Element]]
    [:centered {:optional true} boolean?]
-   [:filter {:optional true} A11yFilter]
+   [:a11y-filter {:optional true} A11yFilterId]
    [:attrs {:default {:fill "white"
                       :stroke "black"}} [:map-of keyword? string?]]
    [:preview-label {:optional true} string?]

--- a/src/renderer/document/events.cljs
+++ b/src/renderer/document/events.cljs
@@ -53,12 +53,12 @@
    (document.handlers/expand-el db id)))
 
 (rf/reg-event-db
- ::toggle-filter
+ ::toggle-a11y-filter
  [persist]
  (fn [db [_ id]]
-   (if (= (:filter (document.handlers/active db)) id)
-     (update-in db (document.handlers/path db) dissoc :filter)
-     (assoc-in db (document.handlers/path db :filter) id))))
+   (if (= (:a11y-filter (document.handlers/active db)) id)
+     (update-in db (document.handlers/path db) dissoc :a11y-filter)
+     (assoc-in db (document.handlers/path db :a11y-filter) id))))
 
 (rf/reg-event-db
  ::swap-colors

--- a/src/renderer/document/subs.cljs
+++ b/src/renderer/document/subs.cljs
@@ -111,13 +111,13 @@
  :-> :elements)
 
 (rf/reg-sub
- ::filter
+ ::a11y-filter
  :<- [::active]
- :-> :filter)
+ :-> :a11y-filter)
 
 (rf/reg-sub
- ::filter-active
- :<- [::filter]
+ ::a11y-filter-active?
+ :<- [::a11y-filter]
  (fn [active-filter [_ k]]
    (= active-filter k)))
 

--- a/src/renderer/element/impl/container/canvas.cljs
+++ b/src/renderer/element/impl/container/canvas.cljs
@@ -2,6 +2,7 @@
   "The main SVG element that hosts all pages."
   (:require
    [re-frame.core :as rf]
+   [renderer.a11y.subs :as-alias a11y.subs]
    [renderer.app.subs :as-alias app.subs]
    [renderer.attribute.hierarchy :as attribute.hierarchy]
    [renderer.document.subs :as-alias document.subs]
@@ -10,7 +11,6 @@
    [renderer.event.impl.drag :as event.impl.drag]
    [renderer.event.impl.keyboard :as event.impl.keyboard]
    [renderer.event.impl.pointer :as event.impl.pointer]
-   [renderer.filters :as filters]
    [renderer.frame.subs :as-alias frame.subs]
    [renderer.ruler.views :as ruler.views]
    [renderer.snap.subs :as-alias snap.subs]
@@ -47,6 +47,7 @@
         pointer-handler (partial event.impl.pointer/handler! el)
         snap? @(rf/subscribe [::snap.subs/active?])
         nearest-neighbor @(rf/subscribe [::snap.subs/nearest-neighbor])
+        a11y-filters @(rf/subscribe [::a11y.subs/filters])
         snapped-el-id (-> nearest-neighbor meta :id)
         snapped-el (when snapped-el-id
                      @(rf/subscribe [::element.subs/entity snapped-el-id]))]
@@ -74,7 +75,7 @@
                   [:filter {:id id
                             :key id}
                    [tag attrs]]))
-           (filters/accessibility))
+           a11y-filters)
 
      (when grid
        [ruler.views/grid])

--- a/src/renderer/element/impl/container/svg.cljs
+++ b/src/renderer/element/impl/container/svg.cljs
@@ -27,7 +27,7 @@
         child-els @(rf/subscribe [::element.subs/filter-visible (:children el)])
         rect-attrs (select-keys attrs [:x :y :width :height])
         text-attrs (select-keys attrs [:x :y])
-        active-filter @(rf/subscribe [::document.subs/filter])
+        active-filter @(rf/subscribe [::document.subs/a11y-filter])
         zoom @(rf/subscribe [::document.subs/zoom])
         pointer-handler (partial event.impl.pointer/handler! el)
         shadow-size (/ 2 zoom)]

--- a/src/renderer/history/db.cljs
+++ b/src/renderer/history/db.cljs
@@ -1,15 +1,14 @@
 (ns renderer.history.db
   (:require
    [renderer.db :refer [Vec2]]
-   [renderer.element.db :refer [Element ElementId]]))
-
-(def Explanation [:* any?])
+   [renderer.element.db :refer [Element ElementId]]
+   [renderer.utils.i18n :refer [Translation]]))
 
 (def HistoryIndex [:or pos-int? zero?])
 
 (def HistoryState
   [:map {:closed true}
-   [:explanation Explanation]
+   [:explanation Translation]
    [:timestamp number?]
    [:index HistoryIndex]
    [:elements {:optional true} [:map-of ElementId Element]]

--- a/src/renderer/history/handlers.cljs
+++ b/src/renderer/history/handlers.cljs
@@ -6,8 +6,8 @@
    [renderer.document.db :refer [DocumentId]]
    [renderer.document.handlers :as document.handlers]
    [renderer.element.handlers :as element.handlers]
-   [renderer.history.db :refer [Explanation History HistoryIndex HistoryState]]
-   [renderer.utils.i18n :refer [t]]
+   [renderer.history.db :refer [History HistoryIndex HistoryState]]
+   [renderer.utils.i18n :refer [t Translation]]
    [renderer.utils.vec :as utils.vec]))
 
 (m/=> path [:function
@@ -182,7 +182,7 @@
   [db]
   (update-in db [:documents (:active-document db)] dissoc :preview-label))
 
-(m/=> create-state [:-> App HistoryIndex Explanation HistoryState])
+(m/=> create-state [:-> App HistoryIndex Translation HistoryState])
 (defn create-state
   [db index explanation]
   (let [new-state {:explanation explanation
@@ -244,7 +244,7 @@
           (recur (update-in db children-path utils.vec/move index new-index)
                  parent))))))
 
-(m/=> finalize [:-> App Explanation App])
+(m/=> finalize [:-> App Translation App])
 (defn finalize
   "Pushes changes to history."
   [db & explanation]

--- a/src/renderer/menubar/views.cljs
+++ b/src/renderer/menubar/views.cljs
@@ -2,6 +2,7 @@
   (:require
    ["@radix-ui/react-menubar" :as Menubar]
    [re-frame.core :as rf]
+   [renderer.a11y.subs :as-alias a11y.subs]
    [renderer.app.events :as-alias app.events]
    [renderer.app.subs :as-alias app.subs]
    [renderer.dialog.events :as-alias dialog.events]
@@ -12,7 +13,6 @@
    [renderer.error.events :as-alias error.events]
    [renderer.error.subs :as-alias error.subs]
    [renderer.events :as-alias events]
-   [renderer.filters :as filters]
    [renderer.frame.events :as-alias frame.events]
    [renderer.history.events :as-alias history.events]
    [renderer.history.subs :as-alias history.subs]
@@ -452,14 +452,14 @@
 
 (defn a11y-submenu
   []
-  (->> (filters/accessibility)
-       (mapv (fn [{:keys [id label]}]
-               {:id id
-                :label label
-                :type :checkbox
-                :icon "a11y"
-                :checked @(rf/subscribe [::document.subs/filter-active id])
-                :action [::document.events/toggle-filter id]}))))
+  (mapv (fn [{:keys [id label]}]
+          {:id id
+           :label (apply t label)
+           :type :checkbox
+           :icon "a11y"
+           :checked @(rf/subscribe [::document.subs/a11y-filter-active? id])
+           :action [::document.events/toggle-a11y-filter id]})
+        @(rf/subscribe [::a11y.subs/filters])))
 
 (defn languages-submenu
   []

--- a/src/renderer/utils/i18n.cljs
+++ b/src/renderer/utils/i18n.cljs
@@ -83,6 +83,8 @@
                     (str value " is not a supported language"))}
    supported-lang?])
 
+(def Translation [:* any?])
+
 (m/=> computed-lang [:-> [:or Lang [:= "system"]] [:maybe string?] Lang])
 (defn computed-lang
   [lang system-lang]
@@ -97,10 +99,10 @@
               (map (fn [[k v]] [k (:dictionary v)]))
               (into {}))})
 
-(m/=> translate [:-> Lang [:* any?] any?])
+(m/=> translate [:-> Lang Translation any?])
 (defn translate
-  [lang args]
-  (apply tempura/tr options [lang] args))
+  [lang translation]
+  (apply tempura/tr options [lang] translation))
 
 (defn tr
   "Translation function that can be called outside of a reactive context."

--- a/src/user.cljs
+++ b/src/user.cljs
@@ -5,6 +5,7 @@
    [config :as config]
    [re-frame.core :as rf]
    [re-frame.db :as rf.db]
+   [renderer.a11y.events :as-alias a11y.events]
    [renderer.document.events :as-alias document.events]
    [renderer.element.events :as-alias element.events]
    [renderer.history.events :as-alias history.events]
@@ -308,6 +309,16 @@
   "Closes the application."
   []
   (rf/dispatch [::window.events/close]))
+
+(defn ^:export register-a11y-filter
+  "Registers an accessibility filter."
+  [v]
+  (rf/dispatch [::a11y.events/register-filter v]))
+
+(defn ^:export deregister-a11y-filter
+  "Deregisters an accessibility filter."
+  [v]
+  (rf/dispatch [::a11y.events/deregister-filter v]))
 
 (defn ^:export help
   "Lists available functions."

--- a/test/a11y_test.cljs
+++ b/test/a11y_test.cljs
@@ -14,14 +14,13 @@
    (let [a11y-filters (rf/subscribe [::a11y.subs/filters])]
 
      (testing "defaults"
-
        (is (= (count @a11y-filters) 10)))
 
      (testing "register"
        (rf/dispatch [::a11y.events/register-filter
                      {:id :blur-x3
                       :tag :feGaussianBlur
-                      :label [[::blur-x3 "blur-x3"]]
+                      :label [[:a11y-filter/blur-x3 "blur-x3"]]
                       :attrs {:in "SourceGraphic"
                               :type "matrix"
                               :stdDeviation "3"}}])

--- a/test/a11y_test.cljs
+++ b/test/a11y_test.cljs
@@ -21,7 +21,7 @@
        (rf/dispatch [::a11y.events/register-filter
                      {:id :blur-x3
                       :tag :feGaussianBlur
-                      :label [[::blur-x2 "blur-x3"]]
+                      :label [[::blur-x3 "blur-x3"]]
                       :attrs {:in "SourceGraphic"
                               :type "matrix"
                               :stdDeviation "3"}}])

--- a/test/a11y_test.cljs
+++ b/test/a11y_test.cljs
@@ -1,0 +1,34 @@
+(ns a11y-test
+  (:require
+   [cljs.test :refer-macros [deftest is testing]]
+   [day8.re-frame.test :as rf.test]
+   [re-frame.core :as rf]
+   [renderer.a11y.events :as-alias a11y.events]
+   [renderer.a11y.subs :as-alias a11y.subs]
+   [renderer.app.events :as-alias app.events]))
+
+(deftest filters
+  (rf.test/run-test-sync
+   (rf/dispatch [::app.events/initialize])
+
+   (let [a11y-filters (rf/subscribe [::a11y.subs/filters])]
+
+     (testing "defaults"
+
+       (is (= (count @a11y-filters) 10)))
+
+     (testing "register"
+       (rf/dispatch [::a11y.events/register-filter
+                     {:id :blur-x3
+                      :tag :feGaussianBlur
+                      :label [[::blur-x2 "blur-x3"]]
+                      :attrs {:in "SourceGraphic"
+                              :type "matrix"
+                              :stdDeviation "3"}}])
+
+       (is (= (count @a11y-filters) 11)))
+
+     (testing "deregister"
+       (rf/dispatch [::a11y.events/deregister-filter :blur-x3])
+
+       (is (= (count @a11y-filters) 10))))))

--- a/test/core_test.cljs
+++ b/test/core_test.cljs
@@ -4,6 +4,8 @@
    [malli.instrument :as m.instrument]
    [re-frame.core :as rf]
    [re-frame.subs :as rf.subs]
+   [renderer.a11y.events]
+   [renderer.a11y.subs]
    [renderer.app.events :as app.events]
    [renderer.app.subs]
    [renderer.dialog.events]

--- a/test/document_test.cljs
+++ b/test/document_test.cljs
@@ -81,21 +81,21 @@
            (is (= @stroke "yellow")))))
 
      (testing "filters"
-       (let [active-filter (rf/subscribe [::document.subs/filter])]
+       (let [a11y-filter (rf/subscribe [::document.subs/a11y-filter])]
          (testing "default state"
-           (is (not @active-filter)))
+           (is (not @a11y-filter)))
 
          (testing "enable filter"
-           (rf/dispatch [::document.events/toggle-filter :blur])
-           (is (= @active-filter :blur)))
+           (rf/dispatch [::document.events/toggle-a11y-filter :blur])
+           (is (= @a11y-filter :blur)))
 
          (testing "change active filter"
-           (rf/dispatch [::document.events/toggle-filter :deuteranopia])
-           (is (= @active-filter :deuteranopia)))
+           (rf/dispatch [::document.events/toggle-a11y-filter :deuteranopia])
+           (is (= @a11y-filter :deuteranopia)))
 
          (testing "disable filter"
-           (rf/dispatch [::document.events/toggle-filter :deuteranopia])
-           (is (not @active-filter)))))
+           (rf/dispatch [::document.events/toggle-a11y-filter :deuteranopia])
+           (is (not @a11y-filter)))))
 
      (testing "collapse/expand elements"
        (let [collapsed-ids (rf/subscribe [::document.subs/collapsed-ids])


### PR DESCRIPTION
This PR introduces an accessibility filter registry. 

- Created a new a11y module on a dedicated directory
- Enhanced filter specs
- We can also register or deregister filters using the embedded repl

We can test this by registering  a new filter using the interactive shell
```clojure
(register-a11y-filter {:id :blur-x3
                       :tag :feGaussianBlur
                       :label [[:a11y-filter/blur-x3 "blur-x3"]]
                       :attrs {:in "SourceGraphic"
                               :type "matrix"
                               :stdDeviation "3"}})
``` 

The new filter will be available under `View` -> `Accessibility filter`
<img width="1114" height="507" alt="Screenshot From 2025-11-07 13-33-24" src="https://github.com/user-attachments/assets/538a578a-fc15-4b01-ae75-05f8d561b0a3" />

We can also deregister the filter
```clojure
(deregister-a11y-filter :blur-x3)
```

Resolves #97