### PR TITLE
Introduce reopen last closed document action

### DIFF
--- a/src/lang/ar-EG.edn
+++ b/src/lang/ar-EG.edn
@@ -671,6 +671,7 @@
   :jpg "JPG"
   :webp "WEBP"
   :gif "GIF"
+  :reopen-last-closed "إعادة فتح آخر مغلق"
   :vector-formats "تنسيقات متجهية"
   :rasterised-formats "تنسيقات نقطية"}
 

--- a/src/lang/de-DE.edn
+++ b/src/lang/de-DE.edn
@@ -714,6 +714,7 @@
   :jpg "JPG"
   :webp "WEBP"
   :gif "GIF"
+  :reopen-last-closed "Zuletzt geschlossenes erneut öffnen"
   :vector-formats "Vektorformate"
   :rasterised-formats "Rasterformate"}
 

--- a/src/lang/el-GR.edn
+++ b/src/lang/el-GR.edn
@@ -718,6 +718,7 @@
   :jpg "JPG"
   :webp "WEBP"
   :gif "GIF"
+  :reopen-last-closed "Επαναφορά τελευταίου κλεισμένου"
   :vector-formats "Μορφές διανυσμάτων"
   :rasterised-formats "Ραστεροποιημένες μορφές"}
 

--- a/src/lang/en-US.edn
+++ b/src/lang/en-US.edn
@@ -683,6 +683,7 @@
   :jpg "JPG"
   :webp "WEBP"
   :gif "GIF"
+  :reopen-last-closed "Reopen last closed"
   :vector-formats "Vector formats"
   :rasterised-formats "Rasterised formats"}
 

--- a/src/lang/es-ES.edn
+++ b/src/lang/es-ES.edn
@@ -701,6 +701,7 @@
   :jpg "JPG"
   :webp "WEBP"
   :gif "GIF"
+  :reopen-last-closed "Reabrir último cerrado"
   :vector-formats "Formatos vectoriales"
   :rasterised-formats "Formatos rasterizados"}
 

--- a/src/lang/fr-FR.edn
+++ b/src/lang/fr-FR.edn
@@ -708,6 +708,7 @@
   :jpg "JPG"
   :webp "WEBP"
   :gif "GIF"
+  :reopen-last-closed "Rouvrir le dernier fermé"
   :vector-formats "Formats vectoriels"
   :rasterised-formats "Formats matriciels"}
 

--- a/src/lang/it-IT.edn
+++ b/src/lang/it-IT.edn
@@ -709,6 +709,7 @@
   :jpg "JPG"
   :webp "WEBP"
   :gif "GIF"
+  :reopen-last-closed "Riapri ultimo chiuso"
   :vector-formats "Formati vettoriali"
   :rasterised-formats "Formati rasterizzati"}
 

--- a/src/lang/ja-JP.edn
+++ b/src/lang/ja-JP.edn
@@ -655,6 +655,7 @@
   :jpg "JPG"
   :webp "WEBP"
   :gif "GIF"
+  :reopen-last-closed "最後に閉じたものを再度開く"
   :vector-formats "ベクター形式"
   :rasterised-formats "ラスター形式"}
 

--- a/src/lang/ko-KR.edn
+++ b/src/lang/ko-KR.edn
@@ -650,6 +650,7 @@
   :jpg "JPG"
   :webp "WEBP"
   :gif "GIF"
+  :reopen-last-closed "마지막으로 닫은 항목 다시 열기"
   :vector-formats "벡터 형식"
   :rasterised-formats "래스터 형식"}
 

--- a/src/lang/nl-NL.edn
+++ b/src/lang/nl-NL.edn
@@ -712,6 +712,7 @@
   :jpg "JPG"
   :webp "WEBP"
   :gif "GIF"
+  :reopen-last-closed "Laatst gesloten opnieuw openen"
   :vector-formats "Vectorformaten"
   :rasterised-formats "Rasterformaten"}
 

--- a/src/lang/pt-PT.edn
+++ b/src/lang/pt-PT.edn
@@ -693,6 +693,7 @@
   :jpg "JPG"
   :webp "WEBP"
   :gif "GIF"
+  :reopen-last-closed "Reabrir último fechado"
   :vector-formats "Formatos vetoriais"
   :rasterised-formats "Formatos rasterizados"}
 

--- a/src/lang/ru-RU.edn
+++ b/src/lang/ru-RU.edn
@@ -694,6 +694,7 @@
   :jpg "JPG"
   :webp "WEBP"
   :gif "GIF"
+  :reopen-last-closed "Открыть последний закрытый"
   :vector-formats "Векторные форматы"
   :rasterised-formats "Растровые форматы"}
 

--- a/src/lang/sv-SE.edn
+++ b/src/lang/sv-SE.edn
@@ -696,6 +696,7 @@
   :jpg "JPG"
   :webp "WEBP"
   :gif "GIF"
+  :reopen-last-closed "Öppna senast stängda igen"
   :vector-formats "Vektorformat"
   :rasterised-formats "Rasterformat"}
 

--- a/src/lang/tr-TR.edn
+++ b/src/lang/tr-TR.edn
@@ -691,6 +691,7 @@
   :jpg "JPG"
   :webp "WEBP"
   :gif "GIF"
+  :reopen-last-closed "Son kapatılanı yeniden aç"
   :vector-formats "Vektör biçimleri"
   :rasterised-formats "Raster biçimleri"}
 

--- a/src/lang/zh-CN.edn
+++ b/src/lang/zh-CN.edn
@@ -617,6 +617,7 @@
   :jpg "JPG"
   :webp "WEBP"
   :gif "GIF"
+  :reopen-last-closed "重新打开上次关闭的"
   :vector-formats "矢量格式"
   :rasterised-formats "光栅格式"}
 

--- a/src/renderer/action/effects.cljs
+++ b/src/renderer/action/effects.cljs
@@ -35,6 +35,9 @@
     :ctrlKey true}
    {:keyCode (utils.key/codes "D")
     :ctrlKey true
+    :shiftKey true}
+   {:keyCode (utils.key/codes "T")
+    :ctrlKey true
     :shiftKey true}])
 
 (defn shortcut-modifier-count

--- a/src/renderer/action/effects.cljs
+++ b/src/renderer/action/effects.cljs
@@ -1,44 +1,7 @@
 (ns renderer.action.effects
   (:require
    [re-frame.core :as rf]
-   [re-pressed.core :as-alias re-pressed]
-   [renderer.utils.key :as utils.key]))
-
-(def prevent-default-keys
-  [{:keyCode (utils.key/codes "EQUALS")}
-   {:keyCode (utils.key/codes "DASH")}
-   {:keyCode (utils.key/codes "RIGHT")}
-   {:keyCode (utils.key/codes "LEFT")}
-   {:keyCode (utils.key/codes "UP")}
-   {:keyCode (utils.key/codes "DOWN")}
-   {:keyCode (utils.key/codes "F1")}
-   {:keyCode (utils.key/codes "F11")}
-   {:keyCode (utils.key/codes "F")
-    :altKey true}
-   {:keyCode (utils.key/codes "E")
-    :altKey true}
-   {:keyCode (utils.key/codes "A")
-    :ctrlKey true}
-   {:keyCode (utils.key/codes "O")
-    :ctrlKey true}
-   {:keyCode (utils.key/codes "S")
-    :ctrlKey true}
-   {:keyCode (utils.key/codes "G")
-    :ctrlKey true}
-   {:keyCode (utils.key/codes "P")
-    :ctrlKey true}
-   {:keyCode (utils.key/codes "W")
-    :ctrlKey true}
-   {:keyCode (utils.key/codes "K")
-    :ctrlKey true}
-   {:keyCode (utils.key/codes "W")
-    :ctrlKey true}
-   {:keyCode (utils.key/codes "D")
-    :ctrlKey true
-    :shiftKey true}
-   {:keyCode (utils.key/codes "T")
-    :ctrlKey true
-    :shiftKey true}])
+   [re-pressed.core :as-alias re-pressed]))
 
 (defn shortcut-modifier-count
   [shortcut]
@@ -62,7 +25,11 @@
                             (into [event] (map vector shortcuts)))))
    :clear-keys []
    :always-listen-keys []
-   :prevent-default-keys prevent-default-keys})
+   ;; Prevent default for all registered shortcuts to avoid conflicts with
+   ;; browser shortcuts. I can't think of a case where we shouldn't do this.
+   ;; In certain cases, the user might have to enter fullscreen mode to use some
+   ;; shortcuts.
+   :prevent-default-keys []})
 
 (rf/reg-fx
  ::update-keydown-rules

--- a/src/renderer/action/effects.cljs
+++ b/src/renderer/action/effects.cljs
@@ -29,7 +29,9 @@
    ;; browser shortcuts. I can't think of a case where we shouldn't do this.
    ;; In certain cases, the user might have to enter fullscreen mode to use some
    ;; shortcuts.
-   :prevent-default-keys []})
+   :prevent-default-keys (->> actions
+                              (keep :shortcuts)
+                              (apply concat))})
 
 (rf/reg-fx
  ::update-keydown-rules

--- a/src/renderer/action/effects.cljs
+++ b/src/renderer/action/effects.cljs
@@ -31,7 +31,7 @@
    ;; shortcuts.
    :prevent-default-keys (->> actions
                               (keep :shortcuts)
-                              (apply concat))})
+                              (reduce concat []))})
 
 (rf/reg-fx
  ::update-keydown-rules

--- a/src/renderer/document/core.cljs
+++ b/src/renderer/document/core.cljs
@@ -140,6 +140,17 @@
                :event [::document.events/export "image/gif"]
                :enabled [::document.subs/entities?]}])
 
+(rf/dispatch [::action.events/register-action
+              {:id :document/reopen-last-closed
+               :label [::reopen-last-closed "Reopen last closed"]
+               :icon "folder"
+               :event [::document.events/reopen-last-closed]
+               :enabled [::document.subs/some-recently-closed?]
+               :available [::app.subs/supported-feature? :file-system]
+               :shortcuts [{:keyCode (utils.key/codes "T")
+                            :ctrlKey true
+                            :shiftKey true}]}])
+
 (rf/dispatch [::action.events/register-action-group
               {:id :export/vector
                :label [::vector-formats "Vector formats"]

--- a/src/renderer/document/events.cljs
+++ b/src/renderer/document/events.cljs
@@ -205,6 +205,13 @@
        :on-error [::recent-error id]}})))
 
 (rf/reg-event-fx
+ ::reopen-last-closed
+ (fn [{:keys [db]} [_]]
+   (let [recently-closed (document.handlers/recently-closed db)]
+     (when (seq recently-closed)
+       {:dispatch [::open-recent (first recently-closed)]}))))
+
+(rf/reg-event-fx
  ::recent-error
  [persist]
  (fn [{:keys [db]} [_ id error]]

--- a/src/renderer/document/events.cljs
+++ b/src/renderer/document/events.cljs
@@ -80,7 +80,9 @@
  (fn [{:keys [db]} [_ id confirm?]]
    {:db (if (or (document.handlers/saved? db id)
                 (not confirm?))
-          (document.handlers/close db id)
+          (-> db
+              (document.handlers/add-recent (document.handlers/entity db id))
+              (document.handlers/close id))
           (dialog.handlers/create
            db
            {:title (i18n.handlers/t db [::save-changes

--- a/src/renderer/document/events.cljs
+++ b/src/renderer/document/events.cljs
@@ -81,7 +81,7 @@
    {:db (if (or (document.handlers/saved? db id)
                 (not confirm?))
           (-> db
-              (document.handlers/add-recent (document.handlers/entity db id))
+              (document.handlers/move-recent-to-front id)
               (document.handlers/close id))
           (dialog.handlers/create
            db

--- a/src/renderer/document/handlers.cljs
+++ b/src/renderer/document/handlers.cljs
@@ -209,3 +209,10 @@
   [document]
   (-> (apply dissoc document config/save-info-keys)
       (pr-str)))
+
+(m/=> recently-closed [:-> App [:vector RecentDocument]])
+(defn recently-closed
+  [db]
+  (->> (:recent db)
+       (filter #(not (open? db (:id %))))
+       (reverse)))

--- a/src/renderer/document/handlers.cljs
+++ b/src/renderer/document/handlers.cljs
@@ -85,6 +85,15 @@
                             (take-last max-recent)
                             (vec))))))
 
+(m/=> move-recent-to-front [:-> App DocumentId App])
+(defn move-recent-to-front
+  [db id]
+  (let [recent (get db :recent)
+        idx (.indexOf (map :id recent) id)]
+    (cond-> db
+      (>= idx 0)
+      (update :recent #(utils.vec/move % idx (dec (count recent)))))))
+
 (m/=> remove-recent [:-> App DocumentId App])
 (defn remove-recent
   [db id]

--- a/src/renderer/document/subs.cljs
+++ b/src/renderer/document/subs.cljs
@@ -31,6 +31,10 @@
    (-> db :recent reverse)))
 
 (rf/reg-sub
+ ::some-recently-closed?
+ (comp boolean seq document.handlers/recently-closed))
+
+(rf/reg-sub
  ::recent-actions
  :<- [::recent]
  (fn [recent _]

--- a/src/renderer/menubar/views.cljs
+++ b/src/renderer/menubar/views.cljs
@@ -17,7 +17,8 @@
 (defn recent-submenu
   []
   (let [recent-items @(rf/subscribe [::document.subs/recent-actions])]
-    (->> [recent-items
+    (->> [[:document/reopen-last-closed]
+          recent-items
           [:document/clear-recent]]
          (keep seq)
          (interpose :separator)


### PR DESCRIPTION
This PR introduces an action that reopens the last closed document, using the recent documents list. A menubar entry and a default keyboard shortcut is also set (Ctrl+ShiftT). Using the recent documents has its pros and cons. The file needs to be saved, and clearing the recent documents would also clear the reopen list. That looks like an acceptable, and also expected behavior to me.

<img width="766" height="407" alt="Screenshot From 2026-04-13 13-07-27" src="https://github.com/user-attachments/assets/a1847e76-5085-433b-98b3-5081e3812210" />

We had to prevent the default behavior of the shortcut to avoid conflicts with the browser's shortcut. Users might need to run the app on full-screen mode to make this shortcut work on web. Instead of adding the shortcut to the existing prevent default list, we now add all registered shortcuts to this list. I can't think of a case where we shouldn't do this. We also avoid future issues when the shortcuts are dynamically set, and unknown conflicts with different browsers.

One more technical issue that had to be resolved, was the order of the recent documents. We now move the closed document at the top of the list, to preserve the correct order on reopen.