### PR TITLE
Introduce now coeffect

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ with some minor additions.
 
 ```text
 module\
-├── core.cljs      -> entry point
+├── core.cljs      -> entry point (will be evaluated on load)
 ├── db.cljs        -> schema, validation
 ├── views.cljs     -> reagent views
 ├── events.cljs    -> event handlers

--- a/src/renderer/app/events.cljs
+++ b/src/renderer/app/events.cljs
@@ -115,13 +115,14 @@
 
 (rf/reg-event-fx
  ::db-loaded
- [(rf/inject-cofx ::effects/guid)]
- (fn [{:keys [db guid]} _]
+ [(rf/inject-cofx ::effects/guid)
+  (rf/inject-cofx ::effects/now)]
+ (fn [{:keys [db now guid]} _]
    {:db (if (:active-document db)
           (snap.handlers/rebuild-tree db)
           (-> db
               (document.handlers/create guid)
-              (history.handlers/finalize [::create-doc "Create document"])))
+              (history.handlers/finalize now [::create-doc "Create document"])))
     ;; The order of the following events is important.
     ;; Changes require thorough testing on all platforms.
     :fx (into [[:dispatch [::error.events/init-reporting]]

--- a/src/renderer/document/events.cljs
+++ b/src/renderer/document/events.cljs
@@ -147,17 +147,20 @@
 
 (rf/reg-event-fx
  ::new
- [(rf/inject-cofx ::effects/guid)]
- (fn [{:keys [db guid]} [_]]
+ [(rf/inject-cofx ::effects/guid)
+  (rf/inject-cofx ::effects/now)]
+ (fn [{:keys [db now guid]} [_]]
    {:db (-> (document.handlers/create db guid)
-            (history.handlers/finalize [::create-doc "Create document"]))}))
+            (history.handlers/finalize now [::create-doc "Create document"]))}))
 
 (rf/reg-event-fx
  ::new-from-template
- [(rf/inject-cofx ::effects/guid)]
- (fn [{:keys [db guid]} [_ size]]
+ [(rf/inject-cofx ::effects/guid)
+  (rf/inject-cofx ::effects/now)]
+ (fn [{:keys [db now guid]} [_ size]]
    {:db (-> (document.handlers/create db guid size)
-            (history.handlers/finalize [::create-doc-from-template
+            (history.handlers/finalize now
+                                       [::create-doc-from-template
                                         "Create document from template"]))}))
 
 (defn string->edn
@@ -286,8 +289,9 @@
 
 (rf/reg-event-fx
  ::load
- [(rf/inject-cofx ::effects/guid)]
- (fn [{:keys [db guid]} [_ document]]
+ [(rf/inject-cofx ::effects/guid)
+  (rf/inject-cofx ::effects/now)]
+ (fn [{:keys [db now guid]} [_ document]]
    (let [migrated-document (utils.compatibility/migrate-document document)
          is-migrated (not= document migrated-document)
          document (merge document.db/default {:id guid} migrated-document)
@@ -298,7 +302,7 @@
               (-> (document.handlers/create-tab (dissoc document :file-handle))
                   (document.handlers/center)
                   (document.handlers/add-recent document)
-                  (history.handlers/finalize [::load-doc "Load document"]))
+                  (history.handlers/finalize now [::load-doc "Load document"]))
 
               (not is-migrated)
               (document.handlers/update-saved-history-index id))

--- a/src/renderer/effects.cljs
+++ b/src/renderer/effects.cljs
@@ -11,6 +11,11 @@
  (fn [coeffects _]
    (assoc coeffects :guid (random-uuid))))
 
+(rf/reg-cofx
+ ::now
+ (fn [coeffects _]
+   (assoc coeffects :now (.now js/Date))))
+
 (rf/reg-fx
  ::clipboard-write
  (fn [{:keys [data on-success on-error]}]

--- a/src/renderer/element/events.cljs
+++ b/src/renderer/element/events.cljs
@@ -31,7 +31,8 @@
  (fn [{:keys [db now]} [_ ids]]
    {:db (-> (partial-right element.handlers/assoc-prop :selected true)
             (reduce (element.handlers/deselect db) ids)
-            (history.handlers/finalize now [::select-elements "Select elements"]))}))
+            (history.handlers/finalize now [::select-elements
+                                            "Select elements"]))}))
 
 (rf/reg-event-fx
  ::toggle-prop
@@ -75,7 +76,9 @@
  [(rf/inject-cofx ::effects/now)]
  (fn [{:keys [db now]} [_ k]]
    {:db (-> (element.handlers/dissoc-attr db k)
-            (history.handlers/finalize now [::remove "Remove %1"] [(name k)]))}))
+            (history.handlers/finalize now
+                                       [::remove "Remove %1"]
+                                       [(name k)]))}))
 
 (rf/reg-event-fx
  ::update-attr

--- a/src/renderer/element/events.cljs
+++ b/src/renderer/element/events.cljs
@@ -14,177 +14,220 @@
    [renderer.utils.element :as utils.element]
    [renderer.utils.extra :refer [partial-right]]))
 
-(rf/reg-event-db
+(rf/reg-event-fx
  ::select
- (fn [db [_ id additive]]
-   (-> (element.handlers/toggle-selection db id additive)
-       (history.handlers/finalize (if additive
-                                    [::modify-selection "Modify selection"]
-                                    [::select-element "Select element"])))))
+ [(rf/inject-cofx ::effects/now)]
+ (fn [{:keys [db now]} [_ id additive]]
+   {:db (-> (element.handlers/toggle-selection db id additive)
+            (history.handlers/finalize now (if additive
+                                             [::modify-selection
+                                              "Modify selection"]
+                                             [::select-element
+                                              "Select element"])))}))
 
-(rf/reg-event-db
+(rf/reg-event-fx
  ::select-ids
- (fn [db [_ ids]]
-   (-> (partial-right element.handlers/assoc-prop :selected true)
-       (reduce (element.handlers/deselect db) ids)
-       (history.handlers/finalize [::select-elements "Select elements"]))))
+ [(rf/inject-cofx ::effects/now)]
+ (fn [{:keys [db now]} [_ ids]]
+   {:db (-> (partial-right element.handlers/assoc-prop :selected true)
+            (reduce (element.handlers/deselect db) ids)
+            (history.handlers/finalize now [::select-elements "Select elements"]))}))
 
-(rf/reg-event-db
+(rf/reg-event-fx
  ::toggle-prop
- (fn [db [_ id k explanation]]
-   (-> (element.handlers/update-prop db id k not)
-       (history.handlers/finalize explanation))))
+ [(rf/inject-cofx ::effects/now)]
+ (fn [{:keys [db now]} [_ id k explanation]]
+   {:db (-> (element.handlers/update-prop db id k not)
+            (history.handlers/finalize now explanation))}))
 
-(rf/reg-event-db
+(rf/reg-event-fx
  ::set-label
- (fn [db [_ id v]]
-   (-> (element.handlers/assoc-prop db id :label v)
-       (history.handlers/finalize [::set-label "Set label"]))))
+ [(rf/inject-cofx ::effects/now)]
+ (fn [{:keys [db now]} [_ id v]]
+   {:db (-> (element.handlers/assoc-prop db id :label v)
+            (history.handlers/finalize now [::set-label "Set label"]))}))
 
-(rf/reg-event-db
+(rf/reg-event-fx
  ::lock
- (fn [db]
-   (-> (element.handlers/assoc-prop db :locked true)
-       (history.handlers/finalize [::lock-selection "Lock selection"]))))
+ [(rf/inject-cofx ::effects/now)]
+ (fn [{:keys [db now]}]
+   {:db (-> (element.handlers/assoc-prop db :locked true)
+            (history.handlers/finalize now [::lock-selection
+                                            "Lock selection"]))}))
 
-(rf/reg-event-db
+(rf/reg-event-fx
  ::unlock
- (fn [db]
-   (-> (element.handlers/assoc-prop db :locked false)
-       (history.handlers/finalize [::unlock-selection "Unlock selection"]))))
+ [(rf/inject-cofx ::effects/now)]
+ (fn [{:keys [db now]}]
+   {:db (-> (element.handlers/assoc-prop db :locked false)
+            (history.handlers/finalize now [::unlock-selection
+                                            "Unlock selection"]))}))
 
-(rf/reg-event-db
+(rf/reg-event-fx
  ::set-attr
- (fn [db [_ k v]]
-   (-> (element.handlers/set-attr db k v)
-       (history.handlers/finalize [::set "Set %1"] [(name k)]))))
+ [(rf/inject-cofx ::effects/now)]
+ (fn [{:keys [db now]} [_ k v]]
+   {:db (-> (element.handlers/set-attr db k v)
+            (history.handlers/finalize now [::set "Set %1"] [(name k)]))}))
 
-(rf/reg-event-db
+(rf/reg-event-fx
  ::remove-attr
- (fn [db [_ k]]
-   (-> (element.handlers/dissoc-attr db k)
-       (history.handlers/finalize [::remove "Remove %1"] [(name k)]))))
+ [(rf/inject-cofx ::effects/now)]
+ (fn [{:keys [db now]} [_ k]]
+   {:db (-> (element.handlers/dissoc-attr db k)
+            (history.handlers/finalize now [::remove "Remove %1"] [(name k)]))}))
 
-(rf/reg-event-db
+(rf/reg-event-fx
  ::update-attr
- (fn [db [_ k f & more]]
-   (-> (apply partial-right element.handlers/update-attr k f more)
-       (reduce db (element.handlers/selected-ids db))
-       (history.handlers/finalize [::update "Update %1"] [(name k)]))))
+ [(rf/inject-cofx ::effects/now)]
+ (fn [{:keys [db now]} [_ k f & more]]
+   {:db (-> (apply partial-right element.handlers/update-attr k f more)
+            (reduce db (element.handlers/selected-ids db))
+            (history.handlers/finalize now
+                                       [::update "Update %1"]
+                                       [(name k)]))}))
 
 (rf/reg-event-db
  ::preview-attr
  (fn [db [_ k v]]
    (element.handlers/set-attr db k v)))
 
-(rf/reg-event-db
+(rf/reg-event-fx
  ::delete
- (fn [db]
-   (-> (element.handlers/delete db)
-       (history.handlers/finalize [::delete-selection "Delete selection"]))))
+ [(rf/inject-cofx ::effects/now)]
+ (fn [{:keys [db now]}]
+   {:db (-> (element.handlers/delete db)
+            (history.handlers/finalize now [::delete-selection
+                                            "Delete selection"]))}))
 
-(rf/reg-event-db
+(rf/reg-event-fx
  ::deselect-all
- (fn [db]
-   (-> (element.handlers/deselect db)
-       (history.handlers/finalize [::deselect-all "Deselect all"]))))
+ [(rf/inject-cofx ::effects/now)]
+ (fn [{:keys [db now]}]
+   {:db (-> (element.handlers/deselect db)
+            (history.handlers/finalize now [::deselect-all "Deselect all"]))}))
 
-(rf/reg-event-db
+(rf/reg-event-fx
  ::select-all
- (fn [db]
-   (-> (element.handlers/select-all db)
-       (history.handlers/finalize [::select-all "Select all"]))))
+ [(rf/inject-cofx ::effects/now)]
+ (fn [{:keys [db now]}]
+   {:db (-> (element.handlers/select-all db)
+            (history.handlers/finalize now [::select-all "Select all"]))}))
 
-(rf/reg-event-db
+(rf/reg-event-fx
  ::select-same-tags
- (fn [db]
-   (-> (element.handlers/select-same-tags db)
-       (history.handlers/finalize [::select-same-tags "Select same tags"]))))
+ [(rf/inject-cofx ::effects/now)]
+ (fn [{:keys [db now]}]
+   {:db (-> (element.handlers/select-same-tags db)
+            (history.handlers/finalize now [::select-same-tags
+                                            "Select same tags"]))}))
 
-(rf/reg-event-db
+(rf/reg-event-fx
  ::invert-selection
- (fn [db]
-   (-> (element.handlers/invert-selection db)
-       (history.handlers/finalize [::invert-selection "Invert selection"]))))
+ [(rf/inject-cofx ::effects/now)]
+ (fn [{:keys [db now]}]
+   {:db (-> (element.handlers/invert-selection db)
+            (history.handlers/finalize now [::invert-selection
+                                            "Invert selection"]))}))
 
-(rf/reg-event-db
+(rf/reg-event-fx
  ::raise
- (fn [db]
-   (-> (element.handlers/update-index db inc)
-       (history.handlers/finalize [::raise-selection "Raise selection"]))))
+ [(rf/inject-cofx ::effects/now)]
+ (fn [{:keys [db now]}]
+   {:db (-> (element.handlers/update-index db inc)
+            (history.handlers/finalize now [::raise-selection
+                                            "Raise selection"]))}))
 
-(rf/reg-event-db
+(rf/reg-event-fx
  ::lower
- (fn [db]
-   (-> (element.handlers/update-index db dec)
-       (history.handlers/finalize [::lower-selection "Lower selection"]))))
+ [(rf/inject-cofx ::effects/now)]
+ (fn [{:keys [db now]}]
+   {:db (-> (element.handlers/update-index db dec)
+            (history.handlers/finalize now [::lower-selection
+                                            "Lower selection"]))}))
 
-(rf/reg-event-db
+(rf/reg-event-fx
  ::raise-to-top
- (fn [db]
-   (-> (element.handlers/update-index db (fn [_i sibling-count]
-                                           (dec sibling-count)))
-       (history.handlers/finalize [::raise-selection-top
-                                   "Raise selection to top"]))))
+ [(rf/inject-cofx ::effects/now)]
+ (fn [{:keys [db now]}]
+   {:db (-> (element.handlers/update-index db (fn [_i sibling-count]
+                                                (dec sibling-count)))
+            (history.handlers/finalize now [::raise-selection-top
+                                            "Raise selection to top"]))}))
 
-(rf/reg-event-db
+(rf/reg-event-fx
  ::lower-to-bottom
- (fn [db]
-   (-> (element.handlers/update-index db #(identity 0))
-       (history.handlers/finalize [::lower-selection-bottom
-                                   "Lower selection to bottom"]))))
+ [(rf/inject-cofx ::effects/now)]
+ (fn [{:keys [db now]}]
+   {:db (-> (element.handlers/update-index db #(identity 0))
+            (history.handlers/finalize now [::lower-selection-bottom
+                                            "Lower selection to bottom"]))}))
 
-(rf/reg-event-db
+(rf/reg-event-fx
  ::align
- (fn [db [_ direction]]
-   (-> (element.handlers/align db direction)
-       (history.handlers/finalize [::update "Update %1"] [direction]))))
+ [(rf/inject-cofx ::effects/now)]
+ (fn [{:keys [db now]} [_ direction]]
+   {:db (-> (element.handlers/align db direction)
+            (history.handlers/finalize now
+                                       [::update "Update %1"]
+                                       [direction]))}))
 
-(rf/reg-event-db
+(rf/reg-event-fx
  ::paste
- (fn [db]
-   (-> (element.handlers/paste db)
-       (history.handlers/finalize [::paste-selection "Paste selection"]))))
+ [(rf/inject-cofx ::effects/now)]
+ (fn [{:keys [db now]}]
+   {:db (-> (element.handlers/paste db)
+            (history.handlers/finalize now [::paste-selection
+                                            "Paste selection"]))}))
 
-(rf/reg-event-db
+(rf/reg-event-fx
  ::paste-in-place
- (fn [db]
-   (-> (element.handlers/paste-in-place db)
-       (history.handlers/finalize [::paste-selection-in-place
-                                   "Paste selection in place"]))))
+ [(rf/inject-cofx ::effects/now)]
+ (fn [{:keys [db now]}]
+   {:db (-> (element.handlers/paste-in-place db)
+            (history.handlers/finalize now [::paste-selection-in-place
+                                            "Paste selection in place"]))}))
 
-(rf/reg-event-db
+(rf/reg-event-fx
  ::paste-styles
- (fn [db]
-   (-> (element.handlers/paste-styles db)
-       (history.handlers/finalize [::paste-styles-to-selection
-                                   "Paste styles to selection"]))))
+ [(rf/inject-cofx ::effects/now)]
+ (fn [{:keys [db now]}]
+   {:db (-> (element.handlers/paste-styles db)
+            (history.handlers/finalize now [::paste-styles-to-selection
+                                            "Paste styles to selection"]))}))
 
-(rf/reg-event-db
+(rf/reg-event-fx
  ::duplicate
- (fn [db]
-   (-> (element.handlers/duplicate db)
-       (history.handlers/finalize [::duplicate-selection
-                                   "Duplicate selection"]))))
+ [(rf/inject-cofx ::effects/now)]
+ (fn [{:keys [db now]}]
+   {:db (-> (element.handlers/duplicate db)
+            (history.handlers/finalize now [::duplicate-selection
+                                            "Duplicate selection"]))}))
 
-(rf/reg-event-db
+(rf/reg-event-fx
  ::translate
- (fn [db [_ offset]]
-   (-> (element.handlers/translate db offset)
-       (history.handlers/finalize [::move-selection "Move selection"]))))
+ [(rf/inject-cofx ::effects/now)]
+ (fn [{:keys [db now]} [_ offset]]
+   {:db (-> (element.handlers/translate db offset)
+            (history.handlers/finalize now [::move-selection
+                                            "Move selection"]))}))
 
-(rf/reg-event-db
+(rf/reg-event-fx
  ::place
- (fn [db [_ position]]
-   (-> (element.handlers/place db position)
-       (history.handlers/finalize [::place-selection "Place selection"]))))
+ [(rf/inject-cofx ::effects/now)]
+ (fn [{:keys [db now]} [_ position]]
+   {:db (-> (element.handlers/place db position)
+            (history.handlers/finalize now [::place-selection
+                                            "Place selection"]))}))
 
-(rf/reg-event-db
+(rf/reg-event-fx
  ::scale
- (fn [db [_ ratio]]
+ [(rf/inject-cofx ::effects/now)]
+ (fn [{:keys [db now]} [_ ratio]]
    (let [pivot-point (-> db element.handlers/bbox utils.bounds/center)]
-     (-> (element.handlers/scale db ratio pivot-point false)
-         (history.handlers/finalize [::scale-selection "Scale selection"])))))
+     {:db (-> (element.handlers/scale db ratio pivot-point false)
+              (history.handlers/finalize now [::scale-selection
+                                              "Scale selection"]))})))
 
 (rf/reg-event-fx
  ::->path
@@ -194,12 +237,13 @@
      :on-success [::finalize->path]
      :on-error [::app.events/toast-error]}}))
 
-(rf/reg-event-db
+(rf/reg-event-fx
  ::finalize->path
- (fn [db [_ elements]]
-   (-> (reduce element.handlers/swap db elements)
-       (history.handlers/finalize [::convert-selection-path
-                                   "Convert selection to path"]))))
+ [(rf/inject-cofx ::effects/now)]
+ (fn [{:keys [db now]} [_ elements]]
+   {:db (-> (reduce element.handlers/swap db elements)
+            (history.handlers/finalize now [::convert-selection-path
+                                            "Convert selection to path"]))}))
 
 (rf/reg-event-fx
  ::stroke->path
@@ -209,13 +253,16 @@
      :on-success [::finalize-stroke->path]
      :on-error [::app.events/toast-error]}}))
 
-(rf/reg-event-db
+(rf/reg-event-fx
  ::finalize-stroke->path
- (fn [db [_ elements]]
-   (-> (reduce element.handlers/swap db elements)
-       (element.handlers/stroke->path)
-       (history.handlers/finalize [::convert-selection-stroke-path
-                                   "Convert selection's stroke to path"]))))
+ [(rf/inject-cofx ::effects/now)]
+ (fn [{:keys [db now]} [_ elements]]
+   {:db (-> (reduce element.handlers/swap db elements)
+            (element.handlers/stroke->path)
+            (history.handlers/finalize
+             now
+             [::convert-selection-stroke-path
+              "Convert selection's stroke to path"]))}))
 
 (rf/reg-event-fx
  ::boolean-operation
@@ -226,78 +273,92 @@
        :on-success [::finalize-boolean-operation operation]
        :on-error [::app.events/toast-error]}})))
 
-(rf/reg-event-db
+(rf/reg-event-fx
  ::finalize-boolean-operation
- (fn [db [_ operation elements]]
-   (-> (reduce element.handlers/swap db elements)
-       (element.handlers/boolean-operation operation)
-       (history.handlers/finalize (case operation
-                                    :unite [::element.core/unite]
-                                    :intersect [::element.core/intersect]
-                                    :subtract [::element.core/subtract]
-                                    :exclude [::element.core/exclude]
-                                    :divide [::element.core/divide])))))
+ [(rf/inject-cofx ::effects/now)]
+ (fn [{:keys [db now]} [_ operation elements]]
+   {:db (-> (reduce element.handlers/swap db elements)
+            (element.handlers/boolean-operation operation)
+            (history.handlers/finalize now
+                                       (case operation
+                                         :unite [::element.core/unite]
+                                         :intersect [::element.core/intersect]
+                                         :subtract [::element.core/subtract]
+                                         :exclude [::element.core/exclude]
+                                         :divide [::element.core/divide])))}))
 
-(rf/reg-event-db
+(rf/reg-event-fx
  ::add
- (fn [db [_ el]]
-   (-> (element.handlers/add db el)
-       (history.handlers/finalize [::create "Create %1"] [(name (:tag el))]))))
+ [(rf/inject-cofx ::effects/now)]
+ (fn [{:keys [db now]} [_ el]]
+   {:db (-> (element.handlers/add db el)
+            (history.handlers/finalize now
+                                       [::create "Create %1"]
+                                       [(name (:tag el))]))}))
 
-(rf/reg-event-db
+(rf/reg-event-fx
  ::import-svg
- (fn [db [_ data]]
-   (-> (element.handlers/import-svg db data)
-       (history.handlers/finalize [::import-svg "Import svg"]))))
+ [(rf/inject-cofx ::effects/now)]
+ (fn [{:keys [db now]} [_ data]]
+   {:db (-> (element.handlers/import-svg db data)
+            (history.handlers/finalize now [::import-svg "Import svg"]))}))
 
-(rf/reg-event-db
+(rf/reg-event-fx
  ::animate
- (fn [db [_ tag attrs]]
-   (-> (element.handlers/animate db tag attrs)
-       (history.handlers/finalize (case tag
-                                    :animate
-                                    [::element.core/animate]
+ [(rf/inject-cofx ::effects/now)]
+ (fn [{:keys [db now]} [_ tag attrs]]
+   {:db (-> (element.handlers/animate db tag attrs)
+            (history.handlers/finalize now
+                                       (case tag
+                                         :animate
+                                         [::element.core/animate]
 
-                                    :animateTransform
-                                    [::element.core/animate-transform]
+                                         :animateTransform
+                                         [::element.core/animate-transform]
 
-                                    :animateMotion
-                                    [::element.core/animate-motion])))))
+                                         :animateMotion
+                                         [::element.core/animate-motion])))}))
 
-(rf/reg-event-db
+(rf/reg-event-fx
  ::set-parent
- (fn [db [_ id parent-id]]
-   (-> (element.handlers/set-parent db id parent-id)
-       (history.handlers/finalize [::set-parent "Set parent"]))))
+ [(rf/inject-cofx ::effects/now)]
+ (fn [{:keys [db now]} [_ id parent-id]]
+   {:db (-> (element.handlers/set-parent db id parent-id)
+            (history.handlers/finalize now [::set-parent "Set parent"]))}))
 
-(rf/reg-event-db
+(rf/reg-event-fx
  ::group
- (fn [db]
-   (-> (element.handlers/group db)
-       (history.handlers/finalize [::group-selection "Group selection"]))))
+ [(rf/inject-cofx ::effects/now)]
+ (fn [{:keys [db now]}]
+   {:db (-> (element.handlers/group db)
+            (history.handlers/finalize now [::group-selection
+                                            "Group selection"]))}))
 
-(rf/reg-event-db
+(rf/reg-event-fx
  ::ungroup
- (fn [db]
-   (-> (element.handlers/ungroup db)
-       (history.handlers/finalize [::ungroup-selection "Ungroup selection"]))))
+ [(rf/inject-cofx ::effects/now)]
+ (fn [{:keys [db now]}]
+   {:db (-> (element.handlers/ungroup db)
+            (history.handlers/finalize now [::ungroup-selection
+                                            "Ungroup selection"]))}))
 
-(rf/reg-event-db
+(rf/reg-event-fx
  ::manipulate-path
- (fn [db [_ action]]
-   (-> (element.handlers/manipulate-path db action)
-       (history.handlers/finalize (case action
-                                    :simplify
-                                    [::element.core/path-simplify]
+ [(rf/inject-cofx ::effects/now)]
+ (fn [{:keys [db now]} [_ action]]
+   {:db (-> (element.handlers/manipulate-path db action)
+            (history.handlers/finalize now (case action
+                                             :simplify
+                                             [::element.core/path-simplify]
 
-                                    :smooth
-                                    [::element.core/path-smooth]
+                                             :smooth
+                                             [::element.core/path-smooth]
 
-                                    :flatten
-                                    [::element.core/path-flatten]
+                                             :flatten
+                                             [::element.core/path-flatten]
 
-                                    :reverse
-                                    [::element.core/path-reverse])))))
+                                             :reverse
+                                             [::element.core/path-reverse])))}))
 
 (rf/reg-event-fx
  ::copy
@@ -311,11 +372,12 @@
 
 (rf/reg-event-fx
  ::cut
- (fn [{:keys [db]} _]
+ [(rf/inject-cofx ::effects/now)]
+ (fn [{:keys [db now]} _]
    (let [els (element.handlers/top-selected-sorted db)]
      {:db (-> (element.handlers/copy db)
               (element.handlers/delete)
-              (history.handlers/finalize [::cut-selection "Cut selection"]))
+              (history.handlers/finalize now [::cut-selection "Cut selection"]))
       :fx [(when (seq els)
              [::effects/clipboard-write
               {:data (utils.element/->svg els)
@@ -328,11 +390,12 @@
      {::element.effects/trace {:data images
                                :on-success [::create-traced-image]}})))
 
-(rf/reg-event-db
+(rf/reg-event-fx
  ::create-traced-image
- (fn [db [_ data]]
-   (-> (element.handlers/import-svg db data)
-       (history.handlers/finalize [::trace-image "Trace image"]))))
+ [(rf/inject-cofx ::effects/now)]
+ (fn [{:keys [db now]} [_ data]]
+   {:db (-> (element.handlers/import-svg db data)
+            (history.handlers/finalize now [::trace-image "Trace image"]))}))
 
 (rf/reg-event-fx
  ::import-file

--- a/src/renderer/element/impl/text.cljs
+++ b/src/renderer/element/impl/text.cljs
@@ -67,13 +67,14 @@
 
 (rf/reg-event-fx
  ::set-text
- (fn [{:keys [db]} [_ id s]]
+ [(rf/inject-cofx ::effects/now)]
+ (fn [{:keys [db now]} [_ id s]]
    {:db (-> (if (empty? s)
               (-> (element.handlers/delete db id)
-                  (history.handlers/finalize [::remove-text "Remove text"]))
+                  (history.handlers/finalize now [::remove-text "Remove text"]))
               (-> (element.handlers/assoc-prop db id :content s)
                   (element.handlers/refresh-bbox id)
-                  (history.handlers/finalize [::set-text "Set text"])))
+                  (history.handlers/finalize now [::set-text "Set text"])))
             (tool.handlers/activate :transform))
     ::effects/focus-canvas nil}))
 

--- a/src/renderer/history/handlers.cljs
+++ b/src/renderer/history/handlers.cljs
@@ -184,10 +184,10 @@
 
 (m/=> create-state [:-> App HistoryIndex Translation HistoryState])
 (defn create-state
-  [db index explanation]
+  [db index timestamp explanation]
   (let [new-state {:explanation explanation
                    :elements (get-in db (element.handlers/path db))
-                   :timestamp (.now js/Date) ; REVIEW: Sideffect
+                   :timestamp timestamp
                    :index index
                    :children []}]
     (cond-> new-state
@@ -247,7 +247,7 @@
 (m/=> finalize [:-> App Translation App])
 (defn finalize
   "Pushes changes to history."
-  [db & explanation]
+  [db timestamp & explanation]
   (if (= (get-in db (element.handlers/path db))
          (-> db history state :elements))
     db
@@ -256,7 +256,7 @@
       (-> db
           (assoc-in (path db :position) index)
           (assoc-in (path db :states index)
-                    (create-state db index explanation))
+                    (create-state db index timestamp explanation))
           (cond->
            current-position
             (-> (update-in (path db :states current-position :children)

--- a/src/renderer/tool/impl/base/edit.cljs
+++ b/src/renderer/tool/impl/base/edit.cljs
@@ -53,7 +53,8 @@
           (element.handlers/clear-ignored)
           (dissoc :clicked-element)
           (element.handlers/toggle-selection (:id element) shift-key)
-          (history.handlers/finalize [::select-element "Select element"]))
+          (history.handlers/finalize (:timestamp e)
+                                     [::select-element "Select element"]))
       (dissoc db :clicked-element))))
 
 (defmethod tool.hierarchy/on-pointer-move :edit
@@ -87,11 +88,11 @@
                                   element.hierarchy/edit offset id lock?))))
 
 (defmethod tool.hierarchy/on-drag-end :edit
-  [db _e]
+  [db e]
   (-> db
       (tool.handlers/set-state :idle)
       (dissoc :clicked-element)
-      (history.handlers/finalize [::edit "Edit"])))
+      (history.handlers/finalize (:timestamp e) [::edit "Edit"])))
 
 (defmethod tool.hierarchy/snapping-points :edit
   [db]

--- a/src/renderer/tool/impl/base/transform.cljs
+++ b/src/renderer/tool/impl/base/transform.cljs
@@ -166,7 +166,8 @@
       (element.handlers/clear-ignored)
 
       (utils.key/arrow? k)
-      (history.handlers/finalize [::move-selection "Move selection"]))))
+      (history.handlers/finalize (:timestamp e)
+                                 [::move-selection "Move selection"]))))
 
 (defmethod tool.hierarchy/on-pointer-down :transform
   [db e]
@@ -183,12 +184,13 @@
 
 (defmethod tool.hierarchy/on-pointer-up :transform
   [db e]
-  (let [{:keys [element]} e]
+  (let [{:keys [element timestamp]} e]
     (-> db
         (dissoc :clicked-element)
         (element.handlers/unignore :bbox)
         (element.handlers/toggle-selection (:id element) (:shift-key e))
-        (history.handlers/finalize (if (:selected element)
+        (history.handlers/finalize timestamp
+                                   (if (:selected element)
                                      [::deselect-element "Deselect element"]
                                      [::select-element "Select element"])))))
 
@@ -451,6 +453,7 @@
 
       (not= state :idle)
       (history.handlers/finalize
+       (:timestamp e)
        (case state
          :select [::modify-selection "Modify selection"]
          :translate [::move-selection "Move selection"]

--- a/src/renderer/tool/impl/draw/brush.cljs
+++ b/src/renderer/tool/impl/draw/brush.cljs
@@ -65,9 +65,9 @@
                                       str " " point)))
 
 (defmethod tool.hierarchy/on-drag-end :brush
-  [db _e]
+  [db e]
   (-> db
-      (history.handlers/finalize [::draw-brush "Draw brush"])
+      (history.handlers/finalize (:timestamp e) [::draw-brush "Draw brush"])
       (tool.handlers/activate :transform)))
 
 (defmethod tool.hierarchy/render :brush

--- a/src/renderer/tool/impl/draw/pencil.cljs
+++ b/src/renderer/tool/impl/draw/pencil.cljs
@@ -39,14 +39,14 @@
                                       str " " point)))
 
 (defmethod tool.hierarchy/on-drag-end :pencil
-  [db _e]
+  [db e]
   (let [path (-> (first (element.handlers/selected db))
                  (utils.element/->path)
                  (update-in [:attrs :d] utils.path/manipulate :smooth)
                  (update-in [:attrs :d] utils.path/manipulate :simplify))]
     (-> db
         (element.handlers/swap path)
-        (history.handlers/finalize [::draw-line "Draw line"])
+        (history.handlers/finalize (:timestamp e) [::draw-line "Draw line"])
         (tool.handlers/activate :transform))))
 
 (rf/dispatch [::action.events/register-action

--- a/src/renderer/tool/impl/element/circle.cljs
+++ b/src/renderer/tool/impl/element/circle.cljs
@@ -42,9 +42,10 @@
     (element.handlers/update-selected db #(assoc-in % [:attrs :r] radius))))
 
 (defmethod tool.hierarchy/on-drag-end :circle
-  [db _e]
+  [db e]
   (-> db
-      (history.handlers/finalize [::create-circle "Create circle"])
+      (history.handlers/finalize (:timestamp e)
+                                 [::create-circle "Create circle"])
       (tool.handlers/activate :transform)))
 
 (defmethod tool.hierarchy/snapping-points :circle

--- a/src/renderer/tool/impl/element/ellipse.cljs
+++ b/src/renderer/tool/impl/element/ellipse.cljs
@@ -53,9 +53,10 @@
     (element.handlers/update-selected db #(reduce assoc-attr % attrs))))
 
 (defmethod tool.hierarchy/on-drag-end :ellipse
-  [db _e]
+  [db e]
   (-> db
-      (history.handlers/finalize [::create-ellipse "Create ellipse"])
+      (history.handlers/finalize (:timestamp e)
+                                 [::create-ellipse "Create ellipse"])
       (tool.handlers/activate :transform)))
 
 (rf/dispatch [::action.events/register-action

--- a/src/renderer/tool/impl/element/line.cljs
+++ b/src/renderer/tool/impl/element/line.cljs
@@ -43,9 +43,9 @@
                                               (assoc-in [:attrs :y2] y)))))
 
 (defmethod tool.hierarchy/on-drag-end :line
-  [db _e]
+  [db e]
   (-> db
-      (history.handlers/finalize [::create-line "Create line"])
+      (history.handlers/finalize (:timestamp e) [::create-line "Create line"])
       (tool.handlers/activate :transform)))
 
 (rf/dispatch [::action.events/register-action

--- a/src/renderer/tool/impl/element/polygon.cljs
+++ b/src/renderer/tool/impl/element/polygon.cljs
@@ -13,10 +13,11 @@
 (tool.hierarchy/derive-tool :polygon ::tool.hierarchy/poly)
 
 (defmethod tool.hierarchy/on-double-click :polygon
-  [db _e]
+  [db e]
   (-> db
       (poly/drop-last-point)
-      (history.handlers/finalize [::create-polygon "Create polygon"])
+      (history.handlers/finalize (:timestamp e)
+                                 [::create-polygon "Create polygon"])
       (tool.handlers/activate :transform)))
 
 (rf/dispatch [::action.events/register-action

--- a/src/renderer/tool/impl/element/polyline.cljs
+++ b/src/renderer/tool/impl/element/polyline.cljs
@@ -13,10 +13,11 @@
 (tool.hierarchy/derive-tool :polyline ::tool.hierarchy/poly)
 
 (defmethod tool.hierarchy/on-double-click :polyline
-  [db _e]
+  [db e]
   (-> db
       (poly/drop-last-point)
-      (history.handlers/finalize [::create-polyline "Create polyline"])
+      (history.handlers/finalize (:timestamp e)
+                                 [::create-polyline "Create polyline"])
       (tool.handlers/activate :transform)))
 
 (rf/dispatch [::action.events/register-action

--- a/src/renderer/tool/impl/element/rect.cljs
+++ b/src/renderer/tool/impl/element/rect.cljs
@@ -58,9 +58,10 @@
         (element.handlers/translate [(- min-x) (- min-y)]))))
 
 (defmethod tool.hierarchy/on-drag-end :rect
-  [db _e]
+  [db e]
   (-> db
-      (history.handlers/finalize [::create-rectangle "Create rectangle"])
+      (history.handlers/finalize (:timestamp e)
+                                 [::create-rectangle "Create rectangle"])
       (tool.handlers/activate :transform)))
 
 (rf/dispatch [::action.events/register-action

--- a/src/renderer/tool/impl/element/svg.cljs
+++ b/src/renderer/tool/impl/element/svg.cljs
@@ -50,9 +50,9 @@
     (element.handlers/update-selected db #(reduce assoc-attr % attrs))))
 
 (defmethod tool.hierarchy/on-drag-end :svg
-  [db _e]
+  [db e]
   (-> db
-      (history.handlers/finalize [::create-svg "Create SVG"])
+      (history.handlers/finalize (:timestamp e) [::create-svg "Create SVG"])
       (tool.handlers/activate :transform)))
 
 (rf/dispatch [::action.events/register-action

--- a/src/renderer/tool/impl/extension/blob.cljs
+++ b/src/renderer/tool/impl/extension/blob.cljs
@@ -49,7 +49,7 @@
         (element.handlers/translate [(- min-x) (- min-y)]))))
 
 (defmethod tool.hierarchy/on-drag-end :blob
-  [db _e]
+  [db e]
   (-> db
-      (history.handlers/finalize [::create-blob "Create blob"])
+      (history.handlers/finalize (:timestamp e) [::create-blob "Create blob"])
       (tool.handlers/activate :transform)))

--- a/src/renderer/tool/impl/misc/dropper.cljs
+++ b/src/renderer/tool/impl/misc/dropper.cljs
@@ -34,15 +34,16 @@
                               [:error ["Eye Dropper is not available in this
                                         environment."]]]))))
 
-(rf/reg-event-db
+(rf/reg-event-fx
  ::success
- (fn [db [_ ^js color]]
-   (let [srgb-color (.-sRGBHex color)]
-     (-> db
-         (document.handlers/assoc-attr :fill srgb-color)
-         (element.handlers/assoc-attr :fill srgb-color)
-         (history.handlers/finalize [::pick-color "Pick color"])
-         (tool.handlers/activate :transform)))))
+ [(rf/inject-cofx ::effects/now)]
+ (fn [{:keys [db now]} [_ ^js color]]
+   {:db (let [srgb-color (.-sRGBHex color)]
+          (-> db
+              (document.handlers/assoc-attr :fill srgb-color)
+              (element.handlers/assoc-attr :fill srgb-color)
+              (history.handlers/finalize now [::pick-color "Pick color"])
+              (tool.handlers/activate :transform)))}))
 
 (rf/reg-event-db
  ::error

--- a/src/renderer/tool/impl/misc/fill.cljs
+++ b/src/renderer/tool/impl/misc/fill.cljs
@@ -24,21 +24,21 @@
   (tool.handlers/set-cursor db "crosshair"))
 
 (defn fill
-  [db]
+  [db timestamp]
   (let [color (document.handlers/attr db :fill)
         el-id (-> db :clicked-element :id)]
     (-> db
         (dissoc :clicked-element)
         (element.handlers/set-attr el-id :fill color)
-        (history.handlers/finalize [::fill "Fill"]))))
+        (history.handlers/finalize timestamp [::fill "Fill"]))))
 
 (defmethod tool.hierarchy/on-pointer-up :fill
-  [db _e]
-  (fill db))
+  [db e]
+  (fill db (:timestamp e)))
 
 (defmethod tool.hierarchy/on-drag-end :fill
-  [db _e]
-  (fill db))
+  [db e]
+  (fill db (:timestamp e)))
 
 (defmethod tool.hierarchy/on-pointer-move :fill
   [db e]

--- a/test/fixtures.cljs
+++ b/test/fixtures.cljs
@@ -174,6 +174,11 @@
  (fn [coeffects _]
    (assoc coeffects :guid (random-uuid))))
 
+(rf/reg-cofx
+ ::effects/now
+ (fn [coeffects _]
+   (assoc coeffects :now (.now js/Date))))
+
 (rf/reg-fx
  ::effects/ipc-on
  (fn [_]))


### PR DESCRIPTION
The purpose of the whole PR is to eliminate the time side effect on `create-state` .
Our `finalize` function now requires a `timestamp` input, and passes it to `create-state`.

A `now` coeffect was introduced to get the current timestamp on `reg-event-fx`. Tools explicitly call `finalize`, but they have access to the `:timestamp` value of the event. 