### PR TITLE
Register language and a11y filter actions as side-effects

### DIFF
--- a/src/lang/ar-EG.edn
+++ b/src/lang/ar-EG.edn
@@ -58,12 +58,14 @@
   :align "محاذاة"
   :view "عرض"
   :zoom "تكبير"
-  :accessibility-filter "مرشح إمكانية الوصول"
-  :language "اللغة"
   :help "مساعدة"}
 
+ :renderer.i18n.core
+ {:language "اللغة"}
+
  :renderer.a11y.core
- {:blur "ضبابية البصر"
+ {:accessibility-filter "مرشح إمكانية الوصول"
+  :blur "ضبابية البصر"
   :heavy-blur "ضبابية البصر الشديدة"
   :protanopia "عمى الألوان الأحمر"
   :protanomaly "ضعف الألوان الأحمر"

--- a/src/lang/de-DE.edn
+++ b/src/lang/de-DE.edn
@@ -58,12 +58,14 @@
   :align "Ausrichten"
   :view "Ansicht"
   :zoom "Zoom"
-  :accessibility-filter "Barrierefreiheitsfilter"
-  :language "Sprache"
   :help "Hilfe"}
 
+ :renderer.i18n.core
+ {:language "Sprache"}
+
  :renderer.a11y.core
- {:blur "Unschärfe"
+ {:accessibility-filter "Barrierefreiheitsfilter"
+  :blur "Unschärfe"
   :heavy-blur "Starke Unschärfe"
   :protanopia "Protanopie"
   :protanomaly "Protanomalie"

--- a/src/lang/el-GR.edn
+++ b/src/lang/el-GR.edn
@@ -58,12 +58,14 @@
   :align "Στοίχιση"
   :view "Προβολή"
   :zoom "Μεγέθυνση"
-  :accessibility-filter "Φίλτρο προσβασιμότητας"
-  :language "Γλώσσα"
   :help "Βοήθεια"}
 
+ :renderer.i18n.core
+ {:language "Γλώσσα"}
+
  :renderer.a11y.core
- {:blur "Θόλωση όρασης"
+ {:accessibility-filter "Φίλτρο προσβασιμότητας"
+  :blur "Θόλωση όρασης"
   :heavy-blur "Έντονη θόλωση όρασης"
   :protanopia "Πρωτανωπία"
   :protanomaly "Πρωτανωμαλία"

--- a/src/lang/en-US.edn
+++ b/src/lang/en-US.edn
@@ -58,12 +58,14 @@
   :align "Align"
   :view "View"
   :zoom "Zoom"
-  :accessibility-filter "Accessibility filter"
-  :language "Language"
   :help "Help"}
 
+ :renderer.i18n.core
+ {:language "Language"}
+
  :renderer.a11y.core
- {:blur "Blur"
+ {:accessibility-filter "Accessibility filter"
+  :blur "Blur"
   :heavy-blur "Heavy Blur"
   :protanopia "Protanopia"
   :protanomaly "Protanomaly"

--- a/src/lang/es-ES.edn
+++ b/src/lang/es-ES.edn
@@ -58,12 +58,14 @@
   :align "Alinear"
   :view "Vista"
   :zoom "Zoom"
-  :accessibility-filter "Filtro de accesibilidad"
-  :language "Idioma"
   :help "Ayuda"}
 
+ :renderer.i18n.core
+ {:language "Idioma"}
+
  :renderer.a11y.core
- {:blur "Desenfoque"
+ {:accessibility-filter "Filtro de accesibilidad"
+  :blur "Desenfoque"
   :heavy-blur "Desenfoque intenso"
   :protanopia "Protanopia"
   :protanomaly "Protanomalía"

--- a/src/lang/fr-FR.edn
+++ b/src/lang/fr-FR.edn
@@ -58,12 +58,14 @@
   :align "Aligner"
   :view "Affichage"
   :zoom "Zoom"
-  :accessibility-filter "Filtre d'accessibilité"
-  :language "Langue"
   :help "Aide"}
 
+ :renderer.i18n.core
+ {:language "Langue"}
+
  :renderer.a11y.core
- {:blur "Flou"
+ {:accessibility-filter "Filtre d'accessibilité"
+  :blur "Flou"
   :heavy-blur "Flou intense"
   :protanopia "Protanopie"
   :protanomaly "Protanomalie"

--- a/src/lang/it-IT.edn
+++ b/src/lang/it-IT.edn
@@ -58,12 +58,15 @@
   :align "Allinea"
   :view "Vista"
   :zoom "Zoom"
-  :accessibility-filter "Filtro accessibilità"
-  :language "Lingua"
+
   :help "Aiuto"}
 
+ :renderer.i18n.core
+ {:language "Lingua"}
+
  :renderer.a11y.core
- {:blur "Sfocatura"
+ {:accessibility-filter "Filtro accessibilità"
+  :blur "Sfocatura"
   :heavy-blur "Sfocatura intensa"
   :protanopia "Protanopia"
   :protanomaly "Protanomalia"

--- a/src/lang/ja-JP.edn
+++ b/src/lang/ja-JP.edn
@@ -58,12 +58,14 @@
   :align "整列"
   :view "表示"
   :zoom "ズーム"
-  :accessibility-filter "アクセシビリティフィルタ"
-  :language "言語"
   :help "ヘルプ"}
 
+ :renderer.i18n.core
+ {:language "言語"}
+
  :renderer.a11y.core
- {:blur "ブラー"
+ {:accessibility-filter "アクセシビリティフィルタ"
+  :blur "ブラー"
   :heavy-blur "強いブラー"
   :protanopia "第一色覚異常"
   :protanomaly "第一色弱"

--- a/src/lang/ko-KR.edn
+++ b/src/lang/ko-KR.edn
@@ -58,12 +58,14 @@
   :align "정렬"
   :view "보기"
   :zoom "확대/축소"
-  :accessibility-filter "접근성 필터"
-  :language "언어"
   :help "도움말"}
 
+ :renderer.i18n.core
+ {:language "언어"}
+
  :renderer.a11y.core
- {:blur "흐림"
+ {:accessibility-filter "접근성 필터"
+  :blur "흐림"
   :heavy-blur "강한 흐림"
   :protanopia "적색맹"
   :protanomaly "적색약"

--- a/src/lang/nl-NL.edn
+++ b/src/lang/nl-NL.edn
@@ -58,12 +58,14 @@
   :align "Uitlijnen"
   :view "Weergave"
   :zoom "Zoom"
-  :accessibility-filter "Toegankelijkheidsfilter"
-  :language "Taal"
   :help "Help"}
 
+ :renderer.i18n.core
+ {:language "Taal"}
+
  :renderer.a11y.core
- {:blur "Vervaging"
+ {:accessibility-filter "Toegankelijkheidsfilter"
+  :blur "Vervaging"
   :heavy-blur "Sterke vervaging"
   :protanopia "Protanopie"
   :protanomaly "Protanomalie"

--- a/src/lang/pt-PT.edn
+++ b/src/lang/pt-PT.edn
@@ -58,12 +58,14 @@
   :align "Alinhar"
   :view "Ver"
   :zoom "Zoom"
-  :accessibility-filter "Filtro de acessibilidade"
-  :language "Idioma"
   :help "Ajuda"}
 
+ :renderer.i18n.core
+ {:language "Idioma"}
+
  :renderer.a11y.core
- {:blur "Desfoque"
+ {:accessibility-filter "Filtro de acessibilidade"
+  :blur "Desfoque"
   :heavy-blur "Desfoque intenso"
   :protanopia "Protanopia"
   :protanomaly "Protanomalia"

--- a/src/lang/ru-RU.edn
+++ b/src/lang/ru-RU.edn
@@ -59,12 +59,14 @@
   :animate "Анимировать"
   :view "Вид"
   :zoom "Масштаб"
-  :accessibility-filter "Фильтр доступности"
-  :language "Язык"
   :help "Справка"}
 
+ :renderer.i18n.core
+ {:language "Язык"}
+
  :renderer.a11y.core
- {:blur "Размытие"
+ {:accessibility-filter "Фильтр доступности"
+  :blur "Размытие"
   :heavy-blur "Сильное размытие"
   :protanopia "Протанопия"
   :protanomaly "Протаномалия"

--- a/src/lang/sv-SE.edn
+++ b/src/lang/sv-SE.edn
@@ -58,12 +58,14 @@
   :align "Justera"
   :view "Visa"
   :zoom "Zoom"
-  :accessibility-filter "Tillgänglighetsfilter"
-  :language "Språk"
   :help "Hjälp"}
 
+ :renderer.i18n.core
+ {:language "Språk"}
+
  :renderer.a11y.core
- {:blur "Suddig"
+ {:accessibility-filter "Tillgänglighetsfilter"
+  :blur "Suddig"
   :heavy-blur "Kraftig suddig"
   :protanopia "Protanopi"
   :protanomaly "Protanomali"

--- a/src/lang/tr-TR.edn
+++ b/src/lang/tr-TR.edn
@@ -58,12 +58,14 @@
   :align "Hizala"
   :view "Görünüm"
   :zoom "Yakınlaştır"
-  :accessibility-filter "Erişilebilirlik filtresi"
-  :language "Dil"
   :help "Yardım"}
 
+ :renderer.i18n.core
+ {:language "Dil"}
+
  :renderer.a11y.core
- {:blur "Bulanık"
+ {:accessibility-filter "Erişilebilirlik filtresi"
+  :blur "Bulanık"
   :heavy-blur "Yoğun bulanık"
   :protanopia "Protanopi"
   :protanomaly "Protanomali"

--- a/src/lang/zh-CN.edn
+++ b/src/lang/zh-CN.edn
@@ -57,12 +57,14 @@
   :align "对齐"
   :view "视图"
   :zoom "缩放"
-  :accessibility-filter "辅助功能过滤器"
-  :language "语言"
   :help "帮助"}
 
+ :renderer.i18n.core
+ {:language "语言"}
+
  :renderer.a11y.core
- {:blur "模糊"
+ {:accessibility-filter "辅助功能过滤器"
+  :blur "模糊"
   :heavy-blur "重度模糊"
   :protanopia "红色盲"
   :protanomaly "红色弱"

--- a/src/renderer/a11y/core.cljs
+++ b/src/renderer/a11y/core.cljs
@@ -2,7 +2,13 @@
   (:require
    [re-frame.core :as rf]
    [renderer.a11y.events :as a11y.events]
-   [renderer.a11y.subs]))
+   [renderer.a11y.subs]
+   [renderer.action.events :as-alias action.events]))
+
+(rf/dispatch [::action.events/register-action-group
+              {:id :a11y/filter
+               :label [::accessibility-filter "Accessibility filter"]
+               :actions []}])
 
 (rf/dispatch [::a11y.events/register-filter
               {:id :blur

--- a/src/renderer/a11y/events.cljs
+++ b/src/renderer/a11y/events.cljs
@@ -1,17 +1,9 @@
 (ns renderer.a11y.events
   (:require
    [re-frame.core :as rf]
-   [renderer.a11y.handlers :as a11y.handlers]))
-
-(rf/reg-event-db
- ::register-filter
- (fn [db [_ a11y-filter]]
-   (a11y.handlers/register-filter db a11y-filter)))
-
-(rf/reg-event-db
- ::deregister-filter
- (fn [db [_ id]]
-   (a11y.handlers/deregister-filter db id)))
+   [renderer.a11y.handlers :as a11y.handlers]
+   [renderer.a11y.subs :as-alias a11y.subs]
+   [renderer.action.events :as-alias action.events]))
 
 (rf/reg-event-db
  ::toggle-active-filter
@@ -20,3 +12,31 @@
    (if (= (:active-filter db) id)
      (dissoc db :active-filter)
      (assoc db :active-filter id))))
+
+(defn action-id
+  [id]
+  (keyword :filter id))
+
+(rf/reg-event-fx
+ ::register-filter
+ (fn [{:keys [db]} [_ a11y-filter]]
+   (let [{:keys [id label]} a11y-filter]
+     {:db (a11y.handlers/register-filter db a11y-filter)
+      :dispatch-n [[::action.events/register-action
+                    {:id (action-id id)
+                     :label label
+                     :icon "a11y"
+                     :active [::a11y.subs/filter-active? id]
+                     :event [::toggle-active-filter id]}]
+                   [::action.events/add-action-to-group
+                    :a11y/filter
+                    (action-id id)]]})))
+
+(rf/reg-event-fx
+ ::deregister-filter
+ (fn [{:keys [db]} [_ id]]
+   {:db (a11y.handlers/deregister-filter db id)
+    :dispatch-n [[::action.events/remove-action-from-group
+                  :a11y/filter
+                  (action-id id)]
+                 [::action.events/deregister-action (action-id id)]]}))

--- a/src/renderer/a11y/subs.cljs
+++ b/src/renderer/a11y/subs.cljs
@@ -1,7 +1,6 @@
 (ns renderer.a11y.subs
   (:require
-   [re-frame.core :as rf]
-   [renderer.a11y.events :as-alias a11y.events]))
+   [re-frame.core :as rf]))
 
 (rf/reg-sub
  ::a11y
@@ -22,15 +21,3 @@
  :<- [::active-filter]
  (fn [active-filter [_ k]]
    (= active-filter k)))
-
-(rf/reg-sub
- ::filter-actions
- :<- [::filters]
- (fn [filters _]
-   (->> filters
-        (mapv (fn [{:keys [id label]}]
-                {:id id
-                 :label label
-                 :icon "a11y"
-                 :active [::filter-active? id]
-                 :event [::a11y.events/toggle-active-filter id]})))))

--- a/src/renderer/i18n/core.cljs
+++ b/src/renderer/i18n/core.cljs
@@ -1,10 +1,23 @@
 (ns renderer.i18n.core
   (:require
    [re-frame.core :as rf]
+   [renderer.action.events :as-alias action.events]
    [renderer.i18n.effects]
    [renderer.i18n.events :as i18n.events]
-   [renderer.i18n.subs]
+   [renderer.i18n.subs :as i18n.subs]
    [taoensso.tempura :refer-macros [load-resource-at-compile-time]]))
+
+(rf/dispatch [::action.events/register-action
+              {:id :lang/system
+               :label [::system "System"]
+               :icon "language"
+               :event [::i18n.events/set-user-lang "system"]
+               :active [::i18n.subs/selected-lang? "system"]}])
+
+(rf/dispatch [::action.events/register-action-group
+              {:id :i18n/language
+               :label [::language "Language"]
+               :actions [:lang/system]}])
 
 (rf/dispatch [::i18n.events/register-language
               {:id "en-US"

--- a/src/renderer/i18n/events.cljs
+++ b/src/renderer/i18n/events.cljs
@@ -1,9 +1,12 @@
 (ns renderer.i18n.events
   (:require
    [re-frame.core :as rf]
+   [renderer.action.events :as-alias action.events]
    [renderer.app.events :refer [persist]]
    [renderer.effects :as-alias effects]
-   [renderer.i18n.handlers :as i18n.handlers]))
+   [renderer.i18n.events :as-alias i18n.events]
+   [renderer.i18n.handlers :as i18n.handlers]
+   [renderer.i18n.subs :as-alias i18n.subs]))
 
 (rf/reg-event-fx
  ::set-lang-attrs
@@ -21,15 +24,33 @@
    {:db (assoc db :user-lang lang)
     :dispatch [::set-lang-attrs]}))
 
-(rf/reg-event-db
- ::register-language
- (fn [db [_ language]]
-   (i18n.handlers/register-language db language)))
+(defn action-id
+  [id]
+  (keyword :lang id))
 
-(rf/reg-event-db
+(rf/reg-event-fx
+ ::register-language
+ (fn [{:keys [db]} [_ language]]
+   (let [{:keys [id locale]} language]
+     {:db (i18n.handlers/register-language db language)
+      :dispatch-n [[::action.events/register-action
+                    {:id (action-id id)
+                     :label [(action-id id) locale]
+                     :icon "language"
+                     :event [::i18n.events/set-user-lang id]
+                     :active [::i18n.subs/selected-lang? id]}]
+                   [::action.events/add-action-to-group
+                    :i18n/language
+                    (action-id id)]]})))
+
+(rf/reg-event-fx
  ::deregister-language
- (fn [db [_ id]]
-   (i18n.handlers/deregister-language db id)))
+ (fn [{:keys [db]} [_ id]]
+   {:db (i18n.handlers/deregister-language db id)
+    :dispatch-n [[::action.events/remove-action-from-group
+                  :i18n/language
+                  (action-id id)]
+                 [::action.events/deregister-action (action-id id)]]}))
 
 (rf/reg-event-db
  ::set-translation

--- a/src/renderer/i18n/subs.cljs
+++ b/src/renderer/i18n/subs.cljs
@@ -1,7 +1,6 @@
 (ns renderer.i18n.subs
   (:require
    [re-frame.core :as rf]
-   [renderer.i18n.events :as-alias i18n.events]
    [renderer.i18n.handlers :as i18n.handlers]))
 
 (rf/reg-sub
@@ -63,21 +62,3 @@
  ::system-lang-code
  :<- [::system-language]
  :-> :code)
-
-(rf/reg-sub
- ::language-actions
- :<- [::languages]
- (fn [languages _]
-   (->> languages
-        (map (fn [[k v]]
-               {:id k
-                :abbr (:code v)
-                :label [k (:locale v)]
-                :icon "language"
-                :event [::i18n.events/set-user-lang k]
-                :active [::selected-lang? k]}))
-        (into [{:id "system"
-                :label [::system "System"]
-                :icon "language"
-                :event [::i18n.events/set-user-lang "system"]
-                :active [::selected-lang? "system"]}]))))

--- a/src/renderer/menubar/views.cljs
+++ b/src/renderer/menubar/views.cljs
@@ -2,7 +2,6 @@
   (:require
    ["@radix-ui/react-menubar" :as Menubar]
    [re-frame.core :as rf]
-   [renderer.a11y.subs :as-alias a11y.subs]
    [renderer.action.views :as action.views]
    [renderer.app.subs :as-alias app.subs]
    [renderer.document.subs :as-alias document.subs]
@@ -118,13 +117,8 @@
               :enabled [::document.subs/some-entities?]
               :actions (zoom-submenu)}
              (action.views/deref-action-group :theme/mode)
-             {:id :a11y
-              :label [::accessibility-filter "Accessibility filter"]
-              :enabled [::document.subs/some-entities?]
-              :actions @(rf/subscribe [::a11y.subs/filter-actions])}
-             {:id :lang
-              :label [::language "Language"]
-              :actions @(rf/subscribe [::i18n.subs/language-actions])}
+             (action.views/deref-action-group :a11y/filter)
+             (action.views/deref-action-group :i18n/language)
              :separator
              :view/toggle-grid
              :view/toggle-rulers

--- a/src/renderer/window/views.cljs
+++ b/src/renderer/window/views.cljs
@@ -1,6 +1,7 @@
 (ns renderer.window.views
   (:require
    ["@radix-ui/react-dropdown-menu" :as DropdownMenu]
+   [clojure.string :as string]
    [re-frame.core :as rf]
    [renderer.action.views :as action.views]
    [renderer.app.events :as-alias app.events]
@@ -15,7 +16,7 @@
    [renderer.window.subs :as-alias window.subs]))
 
 (defn language-item
-  [system-abbr {:keys [id abbr]
+  [system-abbr {:keys [id]
                 :as action}]
   [:> DropdownMenu/CheckboxItem
    {:class "menu-checkbox-item inset"
@@ -25,9 +26,12 @@
     {:class "menu-item-indicator"}
     [views/icon "checkmark"]]
    [:div [action.views/label action]]
-   (if (= id "system")
+   (if (= id :lang/system)
      [:span.font-mono.text-foreground-disabled (or system-abbr "EN")]
-     [:span.font-mono.text-foreground-muted abbr])])
+     [:span.font-mono.text-foreground-muted (->> (name id)
+                                                 (take 2)
+                                                 (apply str)
+                                                 (string/upper-case))])])
 
 (defn dropdown
   [trigger-content dropdown-items]
@@ -102,14 +106,15 @@
 
 (defn language-select
   [system-code code]
-  [dropdown
-   [:button.button
-    {:title (i18n.views/t [::menubar.views/language "Language"])
-     :class "flex gap-1 items-center px-3 uppercase bg-primary font-mono
-             outline-inset"}
-    code]
-   (->> @(rf/subscribe [::i18n.subs/language-actions])
-        (mapv (partial language-item system-code)))])
+  (let [action-group (action.views/deref-action-group :i18n/language)]
+    [dropdown
+     [:button.button
+      {:title (i18n.views/t (:label action-group))
+       :class "flex gap-1 items-center px-3 uppercase bg-primary font-mono
+               outline-inset"}
+      code]
+     (->> (:actions action-group)
+          (mapv (partial language-item system-code)))]))
 
 (defn theme-mode-select
   [mode]

--- a/test/a11y_test.cljs
+++ b/test/a11y_test.cljs
@@ -5,11 +5,17 @@
    [re-frame.core :as rf]
    [renderer.a11y.events :as-alias a11y.events]
    [renderer.a11y.subs :as-alias a11y.subs]
+   [renderer.action.events :as-alias action.events]
    [renderer.app.events :as-alias app.events]))
 
 (deftest filters
   (rf.test/run-test-sync
    (rf/dispatch [::app.events/initialize])
+
+   (rf/dispatch [::action.events/register-action-group
+                 {:id :a11y/filter
+                  :label [::accessibility-filter "Accessibility filter"]
+                  :actions []}])
 
    (let [a11y-filters (rf/subscribe [::a11y.subs/filters])]
 

--- a/test/element_impl_test.cljs
+++ b/test/element_impl_test.cljs
@@ -2,7 +2,8 @@
   (:require
    [cljs.test :refer-macros [deftest is]]
    [clojure.string :as string]
-   [renderer.element.hierarchy :as element.hierarchy]))
+   [renderer.element.hierarchy :as element.hierarchy]
+   [renderer.element.impl.core]))
 
 (deftest circle
   (let [circle-el {:type :element

--- a/test/i18n_test.cljs
+++ b/test/i18n_test.cljs
@@ -3,6 +3,7 @@
    [cljs.test :refer-macros [deftest is testing]]
    [day8.re-frame.test :as rf.test]
    [re-frame.core :as rf]
+   [renderer.action.events :as-alias action.events]
    [renderer.app.events :as-alias app.events]
    [renderer.i18n.events :as-alias i18n.events]
    [renderer.i18n.subs :as-alias i18n.subs]
@@ -11,6 +12,11 @@
 (deftest language
   (rf.test/run-test-sync
    (rf/dispatch [::app.events/initialize])
+
+   (rf/dispatch [::action.events/register-action-group
+                 {:id :i18n/language
+                  :label [::language "Language"]
+                  :actions [:lang/system]}])
 
    (testing "active language"
      (let [lang (rf/subscribe [::i18n.subs/user-lang])


### PR DESCRIPTION
This PR moves language and accessibility filter actions from subscriptions to action registration side effects. By registering actions, we will have the ability to modify them (e.g. assign custom shortcuts in the future). We also move the action groups from the menu-bar views, to their corresponding domain module (a11y, i18n).