### PR TITLE
Enhanced tool hierarchy

### DIFF
--- a/src/renderer/app/core.cljs
+++ b/src/renderer/app/core.cljs
@@ -5,6 +5,7 @@
    [renderer.app.effects]
    [renderer.app.events :as app.events]
    [renderer.app.subs :as app.subs]
+   [renderer.tool.impl.misc.guide :as-alias tool.impl.misc.guide]
    [renderer.tool.subs :as tool.subs]
    [renderer.utils.key :as utils.key]))
 
@@ -40,7 +41,7 @@
                :label [::lock-guides "Lock guides"]
                :icon "ruler-straight"
                :event [::app.events/toggle-guides-locked]
-               :enabled [::tool.subs/not-active? :guide]
+               :enabled [::tool.subs/not-active? ::tool.impl.misc.guide/guide]
                :active [::app.subs/guides-locked?]}])
 
 (rf/dispatch [::action.events/register-action

--- a/src/renderer/app/db.cljs
+++ b/src/renderer/app/db.cljs
@@ -22,6 +22,7 @@
    [renderer.theme.db :refer [Theme]]
    [renderer.timeline.db :refer [Timeline]]
    [renderer.tool.db :refer [Handle Tool State Cursor]]
+   [renderer.tool.impl.base.transform.core :as-alias tool.transform]
    [renderer.window.db :refer [Window]]))
 
 (def Platform
@@ -40,7 +41,7 @@
 
 (def App
   [:map {:closed true}
-   [:tool {:default :transform} Tool]
+   [:tool {:default ::tool.transform/transform} Tool]
    [:cached-tool {:optional true} Tool]
    [:active-pointers {:default {}} [:map-of PointerId PointerEvent]]
    [:pointer-pos {:default [0 0]} Vec2]

--- a/src/renderer/app/views.cljs
+++ b/src/renderer/app/views.cljs
@@ -27,6 +27,7 @@
    [renderer.theme.subs :as-alias theme.subs]
    [renderer.timeline.views :as timeline.views]
    [renderer.tool.hierarchy :as tool.hierarchy]
+   [renderer.tool.impl.misc.guide :as-alias tool.impl.misc.guide]
    [renderer.tool.subs :as-alias tool.subs]
    [renderer.toolbar.status :as toolbar.status]
    [renderer.toolbar.tools :as toolbar.tools]
@@ -118,7 +119,8 @@
      [views/icon-button
       (if locked? "lock" "unlock")
       {:class "button-size-small rounded-xs m-0 bg-transparent!"
-       :disabled @(rf/subscribe [::tool.subs/active? :guide])
+       :disabled @(rf/subscribe [::tool.subs/active?
+                                 ::tool.impl.misc.guide/guide])
        :title (i18n.views/t (if locked?
                               [::unlock "Unlock"]
                               [::lock "Lock"]))
@@ -175,7 +177,8 @@
   []
   (let [rulers? @(rf/subscribe [::app.subs/rulers?])
         md? @(rf/subscribe [::window.subs/md?])
-        active? @(rf/subscribe [::tool.subs/active? :guide])
+        active? @(rf/subscribe [::tool.subs/active?
+                                ::tool.impl.misc.guide/guide])
         bg-class (if active? "bg-accent" "bg-primary")]
     [:div.flex.flex-col.flex-1.h-full.gap-px.overflow-hidden
      [:div

--- a/src/renderer/attribute/impl/href.cljs
+++ b/src/renderer/attribute/impl/href.cljs
@@ -57,5 +57,5 @@
  ::update-attrs
  (fn [{:keys [db]} [_ el]]
    (let [attrs (select-keys (:attrs el) [:href :width :height])]
-     {:db (tool.handlers/activate db :transform)
+     {:db (tool.handlers/deactivate db)
       :dispatch-n (mapv (fn [[k v]] [::element.events/set-attr k v]) attrs)})))

--- a/src/renderer/element/events.cljs
+++ b/src/renderer/element/events.cljs
@@ -187,7 +187,7 @@
  ::->path
  (fn [{:keys [db]}]
    (when (= (:state db) :idle)
-     {:db (tool.handlers/activate db :transform)
+     {:db (tool.handlers/deactivate db)
       ::element.effects/->path
       {:data (element.handlers/selected db)
        :on-success [::finalize->path]
@@ -203,7 +203,7 @@
  ::stroke->path
  (fn [{:keys [db]}]
    (when (= (:state db) :idle)
-     {:db (tool.handlers/activate db :transform)
+     {:db (tool.handlers/deactivate db)
       ::element.effects/->path
       {:data (element.handlers/selected db)
        :on-success [::finalize-stroke->path]
@@ -222,7 +222,7 @@
  (fn [{:keys [db]} [_ operation]]
    (when (and (= (:state db) :idle)
               (seq (rest (element.handlers/selected db))))
-     {:db (tool.handlers/activate db :transform)
+     {:db (tool.handlers/deactivate db)
       ::element.effects/->path
       {:data (element.handlers/selected db)
        :on-success [::finalize-boolean-operation operation]
@@ -297,7 +297,7 @@
  (fn [{:keys [db]} _]
    (let [els (element.handlers/top-selected-sorted db)]
      (when (= (:state db) :idle)
-       {:db (-> (tool.handlers/activate db :transform)
+       {:db (-> (tool.handlers/deactivate db)
                 (element.handlers/copy))
         :fx [(when (seq els)
                [::effects/clipboard-write
@@ -322,7 +322,7 @@
  (fn [{:keys [db]} [_]]
    (let [images (element.handlers/filter-selected-by-tag db :image)]
      (when (= (:state db) :idle)
-       {:db (tool.handlers/activate db :transform)
+       {:db (tool.handlers/deactivate db)
         ::element.effects/trace {:data images
                                  :on-success [::create-traced-image]}}))))
 

--- a/src/renderer/element/impl/text.cljs
+++ b/src/renderer/element/impl/text.cljs
@@ -76,7 +76,7 @@
               (-> (element.handlers/assoc-prop db id :content s)
                   (element.handlers/refresh-bbox id)
                   (history.handlers/finalize now [::set-text "Set text"])))
-            (tool.handlers/activate :transform))
+            (tool.handlers/deactivate))
     ::effects/focus-canvas nil}))
 
 (defmethod element.hierarchy/render :text

--- a/src/renderer/history/events.cljs
+++ b/src/renderer/history/events.cljs
@@ -79,7 +79,7 @@
   "Returns an interceptor that:
    1. Checks if (:state db) is :idle, short-circuiting if not.
    2. Injects a performance timestamp into coeffects as :now.
-   3. Activates the :transform tool on the db in coeffects.
+   3. Deactivates the current tool.
    4. After the handler runs, calls history.handlers/finalize on the
       resulting db.
 
@@ -102,8 +102,7 @@
                    (rf/assoc-coeffect :now (.now js/performance))
 
                    (:active-document db)
-                   (rf/assoc-coeffect :db
-                                      (tool.handlers/activate db :transform)))
+                   (rf/assoc-coeffect :db (tool.handlers/deactivate db)))
                  (assoc context :queue []))))
    :after (fn [context]
             (if-let [db (rf/get-effect context :db)]
@@ -112,7 +111,6 @@
                     expl (if (fn? (first explanation))
                            ((first explanation) event)
                            explanation)]
-                (rf/assoc-effect context :db
-                                 (apply history.handlers/finalize
-                                        db now expl)))
+                (rf/assoc-effect context :db (apply history.handlers/finalize
+                                                    db now expl)))
               context))))

--- a/src/renderer/input/handlers.cljs
+++ b/src/renderer/input/handlers.cljs
@@ -12,7 +12,8 @@
    [renderer.input.effects :as-alias input.effects]
    [renderer.snap.handlers :as snap.handlers]
    [renderer.tool.handlers :as tool.handlers]
-   [renderer.tool.hierarchy :as tool.hierarchy]))
+   [renderer.tool.hierarchy :as tool.hierarchy]
+   [renderer.tool.impl.base.pan :as-alias tool.impl.base.pan]))
 
 (m/=> adjusted-pointer-pos [:-> App Vec2 Vec2])
 (defn adjusted-pointer-pos
@@ -85,7 +86,7 @@
   (let [{:keys [pointer-offset tool dom-rect drag-pointer]} db
         {:keys [pointer-pos]} e]
     (cond-> db
-      (and (not= tool :pan)
+      (and (not= tool ::tool.impl.base.pan/pan)
            (drag-pointer? db e))
       (tool.handlers/pan-out-of-canvas dom-rect pointer-pos pointer-offset)
 
@@ -130,7 +131,7 @@
       (assoc-in [:active-pointers pointer-id] e)
 
       (= button :middle)
-      (-> (tool.handlers/set-cached :pan))
+      (-> (tool.handlers/set-cached ::tool.impl.base.pan/pan))
 
       (or (= button :middle)
           (and (= button :left) (empty? active-pointers)))
@@ -213,8 +214,8 @@
   [db e]
   (cond-> db
     (and (= (:code e) "Space")
-         (not= (:tool db) :pan))
-    (tool.handlers/set-cached :pan)
+         (not= (:tool db) ::tool.impl.base.pan/pan))
+    (tool.handlers/set-cached ::tool.impl.base.pan/pan)
 
     (and (= (:code e) "KeyX")
          (not (-> db :snap :transient-active)))

--- a/src/renderer/ruler/views.cljs
+++ b/src/renderer/ruler/views.cljs
@@ -8,6 +8,7 @@
    [renderer.frame.subs :as-alias frame.subs]
    [renderer.ruler.subs :as-alias ruler.subs]
    [renderer.tool.events :as tool.events]
+   [renderer.tool.impl.misc.guide :as-alias tool.impl.misc.guide]
    [renderer.tool.subs :as-alias tool.subs]
    [renderer.window.subs :as-alias window.subs]))
 
@@ -94,7 +95,8 @@
   (let [[x y] @(rf/subscribe [::frame.subs/viewbox])
         zoom @(rf/subscribe [::document.subs/zoom])
         steps-coll @(rf/subscribe [::ruler.subs/steps-coll orientation])
-        active? @(rf/subscribe [::tool.subs/active? :guide])
+        active? @(rf/subscribe [::tool.subs/active?
+                                ::tool.impl.misc.guide/guide])
         vertical (= orientation :vertical)]
     (into [:g]
           (map-indexed
@@ -141,7 +143,7 @@
                          ;; through a panel separator.
                          (when-not (.-defaultPrevented e)
                            (rf/dispatch [::tool.events/activate
-                                         :guide
+                                         ::tool.impl.misc.guide/guide
                                          :orientation orientation])))}
      (when md? [bbox-rect orientation])
      [base-lines orientation]

--- a/src/renderer/tool/db.cljs
+++ b/src/renderer/tool/db.cljs
@@ -1,12 +1,13 @@
 (ns renderer.tool.db
   (:require
    [renderer.element.db :refer [ElementId]]
+   [renderer.hierarchy :as hierarchy]
    [renderer.i18n.db :refer [Translation]]
    [renderer.tool.hierarchy :as tool.hierarchy]))
 
 (defn tool?
   [tool]
-  (isa? @tool.hierarchy/hierarchy tool ::tool.hierarchy/tool))
+  (isa? @hierarchy/hierarchy tool ::tool.hierarchy/tool))
 
 (def Tool
   [:fn {:error/fn (fn [{:keys [value]} _]

--- a/src/renderer/tool/events.cljs
+++ b/src/renderer/tool/events.cljs
@@ -2,13 +2,16 @@
   (:require
    [re-frame.core :as rf]
    [renderer.element.events :as-alias element.events]
-   [renderer.tool.handlers :as tool.handlers]))
+   [renderer.tool.db :as tool.db]
+   [renderer.tool.handlers :as tool.handlers]
+   [renderer.tool.impl.base.transform.core :as-alias tool.impl.base.transform]))
 
 (rf/reg-event-db
  ::activate
  (fn [db [_ tool & {:as opts}]]
    (cond-> db
-     (:active-document db)
+     (and (tool.db/tool? tool)
+          (:active-document db))
      (tool.handlers/activate tool opts))))
 
 (rf/reg-event-db
@@ -19,7 +22,7 @@
 (rf/reg-event-fx
  ::cancel
  (fn [{:keys [db]} _]
-   (if (and (= (:tool db) :transform)
+   (if (and (= (:tool db) ::tool.impl.base.transform/transform)
             (= (:state db) :idle))
      {:dispatch [::element.events/deselect-all]}
      {:db (tool.handlers/cancel db)})))

--- a/src/renderer/tool/handlers.cljs
+++ b/src/renderer/tool/handlers.cljs
@@ -9,7 +9,9 @@
    [renderer.history.handlers :as history.handlers]
    [renderer.snap.handlers :as snap.handlers]
    [renderer.tool.db :refer [Tool State Cursor]]
-   [renderer.tool.hierarchy :as tool.hierarchy]))
+   [renderer.tool.hierarchy :as tool.hierarchy]
+   [renderer.tool.impl.base.edit :as-alias tool.impl.base.edit]
+   [renderer.tool.impl.base.transform.core :as-alias tool.impl.base.transform]))
 
 (m/=> set-state [:-> App State App])
 (defn set-state
@@ -44,6 +46,16 @@
         (dissoc :drag :pointer-offset :clicked-element)
         (snap.handlers/rebuild-tree)
         (tool.hierarchy/on-activate props))))
+
+(m/=> deactivate [:-> App App])
+(defn deactivate
+  [db]
+  (activate db ::tool.impl.base.transform/transform))
+
+(m/=> edit [:-> App App])
+(defn edit
+  [db]
+  (activate db ::tool.impl.base.edit/edit))
 
 (m/=> pointer-delta [:-> App Vec2])
 (defn pointer-delta
@@ -126,11 +138,10 @@
   (cond-> db
     :always
     (-> (activate (:tool db))
-        (history.handlers/reset-state)
-        (tool.hierarchy/on-cancel))
+        (history.handlers/reset-state))
 
     (= (:state db) :idle)
-    (activate :transform)
+    (deactivate)
 
     (:cached-tool db)
     (reset-cached)

--- a/src/renderer/tool/hierarchy.cljs
+++ b/src/renderer/tool/hierarchy.cljs
@@ -1,71 +1,66 @@
-(ns renderer.tool.hierarchy)
-
-(defonce hierarchy (atom (make-hierarchy)))
-
-(defn derive!
-  [tool parent]
-  (swap! hierarchy derive tool parent))
+(ns renderer.tool.hierarchy
+  (:require
+   [renderer.hierarchy :as hierarchy]))
 
 (defmulti on-pointer-down
   (fn [db _e] [(:tool db) (:state db)])
-  :hierarchy hierarchy)
+  :hierarchy hierarchy/hierarchy)
 
 (defmulti on-pointer-up
   (fn [db _e] [(:tool db) (:state db)])
-  :hierarchy hierarchy)
+  :hierarchy hierarchy/hierarchy)
 
 (defmulti on-pointer-move
   (fn [db _e] [(:tool db) (:state db)])
-  :hierarchy hierarchy)
+  :hierarchy hierarchy/hierarchy)
 
 (defmulti on-double-click
   (fn [db _e] [(:tool db) (:state db)])
-  :hierarchy hierarchy)
+  :hierarchy hierarchy/hierarchy)
 
 (defmulti on-drag-start
   (fn [db _e] [(:tool db) (:state db)])
-  :hierarchy hierarchy)
+  :hierarchy hierarchy/hierarchy)
 
 (defmulti on-drag
   (fn [db _e] [(:tool db) (:state db)])
-  :hierarchy hierarchy)
+  :hierarchy hierarchy/hierarchy)
 
 (defmulti on-drag-end
   (fn [db _e] [(:tool db) (:state db)])
-  :hierarchy hierarchy)
+  :hierarchy hierarchy/hierarchy)
 
 (defmulti on-context-menu
   (fn [db _e] [(:tool db) (:state db)])
-  :hierarchy hierarchy)
+  :hierarchy hierarchy/hierarchy)
 
 (defmulti on-key-up
   (fn [db _e] [(:tool db) (:state db)])
-  :hierarchy hierarchy)
+  :hierarchy hierarchy/hierarchy)
 
 (defmulti on-key-down
   (fn [db _e] [(:tool db) (:state db)])
-  :hierarchy hierarchy)
+  :hierarchy hierarchy/hierarchy)
 
 (defmulti snapping-points
   (fn [db _e] [(:tool db) (:state db)])
-  :hierarchy hierarchy)
+  :hierarchy hierarchy/hierarchy)
 
 (defmulti snapping-elements
   (fn [db _e] [(:tool db) (:state db)])
-  :hierarchy hierarchy)
+  :hierarchy hierarchy/hierarchy)
 
 (defmulti help
   (fn [tool state] [tool state])
-  :hierarchy hierarchy)
+  :hierarchy hierarchy/hierarchy)
 
 (defmulti on-activate
   (fn [db & {:as _props}] (:tool db))
-  :hierarchy hierarchy)
+  :hierarchy hierarchy/hierarchy)
 
-(defmulti on-deactivate :tool :hierarchy hierarchy)
-(defmulti on-cancel :tool :hierarchy hierarchy)
-(defmulti render identity :hierarchy hierarchy)
-(defmulti right-panel identity :hierarchy hierarchy)
+(defmulti on-deactivate :tool :hierarchy hierarchy/hierarchy)
+(defmulti render identity :hierarchy hierarchy/hierarchy)
+(defmulti right-panel identity :hierarchy hierarchy/hierarchy)
 
 (defmethod on-pointer-down :default [db _e] db)
 (defmethod on-pointer-up :default [db _e] db)
@@ -79,7 +74,6 @@
 (defmethod on-key-down :default [db _e] db)
 (defmethod on-activate :default [db & {:as _props}] db)
 (defmethod on-deactivate :default [db] db)
-(defmethod on-cancel :default [db] db)
 (defmethod render :default [])
 (defmethod snapping-points :default [])
 (defmethod snapping-elements :default [])

--- a/src/renderer/tool/impl/base/edit.cljs
+++ b/src/renderer/tool/impl/base/edit.cljs
@@ -7,6 +7,7 @@
    [renderer.element.handlers :as element.handlers]
    [renderer.element.hierarchy :as element.hierarchy]
    [renderer.element.subs :as-alias element.subs]
+   [renderer.hierarchy :as hierarchy]
    [renderer.history.handlers :as history.handlers]
    [renderer.i18n.views :as i18n.views]
    [renderer.snap.handlers :as snap.handlers]
@@ -19,32 +20,32 @@
    [renderer.utils.svg :as utils.svg]
    [renderer.views :as views]))
 
-(tool.hierarchy/derive! :edit ::tool.hierarchy/tool)
+(hierarchy/derive! ::edit ::tool.hierarchy/tool)
 
-(defmethod tool.hierarchy/help [:edit :idle]
+(defmethod tool.hierarchy/help [::edit :idle]
   []
   [:<>
    (i18n.views/t [::help-idle-drag "Drag a handle to modify your shape."])
    (i18n.views/t [::help-idle-click
                   "Click on an element to change selection"])])
 
-(defmethod tool.hierarchy/help [:edit :edit]
+(defmethod tool.hierarchy/help [::edit :edit]
   []
   (i18n.views/t [::help-edit "Hold %1 to restrict direction."]
                 [[views/kbd "Ctrl"]]))
 
-(defmethod tool.hierarchy/help [:edit :type]
+(defmethod tool.hierarchy/help [::edit :type]
   []
   (i18n.views/t [::help-type "Enter your text."]))
 
-(defmethod tool.hierarchy/on-pointer-down [:edit :idle]
+(defmethod tool.hierarchy/on-pointer-down [::edit :idle]
   [db e]
   (let [{:keys [element]} e]
     (cond-> db
       element
       (assoc :clicked-element element))))
 
-(defmethod tool.hierarchy/on-pointer-up [:edit :idle]
+(defmethod tool.hierarchy/on-pointer-up [::edit :idle]
   [db e]
   (let [{:keys [shift-key button element]} e]
     (if-not (and (= button :right)
@@ -57,7 +58,7 @@
                                      [::select-element "Select element"]))
       (dissoc db :clicked-element))))
 
-(defmethod tool.hierarchy/on-pointer-move [:edit :idle]
+(defmethod tool.hierarchy/on-pointer-move [::edit :idle]
   [db e]
   (let [el-id (-> e :element :id)]
     (cond-> db
@@ -67,13 +68,13 @@
       el-id
       (element.handlers/hover el-id))))
 
-(defmethod tool.hierarchy/on-drag-start [:edit :idle]
+(defmethod tool.hierarchy/on-drag-start [::edit :idle]
   [db e]
   (cond-> db
     (= (-> e :element :type) :handle)
     (tool.handlers/set-state :edit)))
 
-(defmethod tool.hierarchy/on-drag [:edit :edit]
+(defmethod tool.hierarchy/on-drag [::edit :edit]
   [db e]
   (let [{:keys [element-id id]} (:clicked-element db)
         lock? (or (:ctrl-key e) (tool.handlers/multi-touch? db))
@@ -87,14 +88,14 @@
       (element.handlers/update-el element-id
                                   element.hierarchy/edit offset id lock?))))
 
-(defmethod tool.hierarchy/on-drag-end [:edit :edit]
+(defmethod tool.hierarchy/on-drag-end [::edit :edit]
   [db e]
   (-> db
       (tool.handlers/set-state :idle)
       (dissoc :clicked-element)
       (history.handlers/finalize (:timestamp e) [::edit "Edit"])))
 
-(defmethod tool.hierarchy/snapping-points [:edit :edit]
+(defmethod tool.hierarchy/snapping-points [::edit :edit]
   [db]
   (when-let [el (:clicked-element db)]
     [(with-meta
@@ -104,15 +105,15 @@
                  (or (:label el)
                      [::handle "handle"]))})]))
 
-(defmethod tool.hierarchy/snapping-elements [:edit :idle]
+(defmethod tool.hierarchy/snapping-elements [::edit :idle]
   [db]
   (element.handlers/non-selected-visible db))
 
-(defmethod tool.hierarchy/snapping-elements [:edit :edit]
+(defmethod tool.hierarchy/snapping-elements [::edit :edit]
   [db]
   (element.handlers/non-selected-visible db))
 
-(defmethod tool.hierarchy/render :edit
+(defmethod tool.hierarchy/render ::edit
   []
   (let [selected-elements @(rf/subscribe [::element.subs/selected])]
     (->> selected-elements
@@ -130,6 +131,6 @@
               {:id :tool/edit
                :label [::tool-edit "Edit"]
                :icon "edit"
-               :event [::tool.events/activate :edit]
-               :active [::tool.subs/active? :edit]
+               :event [::tool.events/activate ::edit]
+               :active [::tool.subs/active? ::edit]
                :shortcuts [{:keyCode (utils.key/codes "E")}]}])

--- a/src/renderer/tool/impl/base/pan.cljs
+++ b/src/renderer/tool/impl/base/pan.cljs
@@ -6,6 +6,7 @@
    [renderer.app.effects :as-alias app.effects]
    [renderer.app.handlers :as app.handlers]
    [renderer.frame.handlers :as frame.handlers]
+   [renderer.hierarchy :as hierarchy]
    [renderer.i18n.views :as i18n.views]
    [renderer.snap.handlers :as snap.handlers]
    [renderer.tool.events :as-alias tool.events]
@@ -14,36 +15,36 @@
    [renderer.tool.subs :as-alias tool.subs]
    [renderer.utils.key :as utils.key]))
 
-(tool.hierarchy/derive! :pan ::tool.hierarchy/tool)
+(hierarchy/derive! ::pan ::tool.hierarchy/tool)
 
-(defmethod tool.hierarchy/on-activate :pan
+(defmethod tool.hierarchy/on-activate ::pan
   [db]
   (tool.handlers/set-cursor db "grab"))
 
-(defmethod tool.hierarchy/help [:pan :idle]
+(defmethod tool.hierarchy/help [::pan :idle]
   []
   (i18n.views/t [::click-and-drag "Click and drag to pan."]))
 
-(defmethod tool.hierarchy/help [:pan :pan]
+(defmethod tool.hierarchy/help [::pan :pan]
   []
   (i18n.views/t [::release-to-stop "Release to stop panning."]))
 
-(defmethod tool.hierarchy/on-pointer-up [:pan :idle]
+(defmethod tool.hierarchy/on-pointer-up [::pan :idle]
   [db _e]
   (tool.handlers/set-cursor db "grab"))
 
-(defmethod tool.hierarchy/on-pointer-down [:pan :idle]
+(defmethod tool.hierarchy/on-pointer-down [::pan :idle]
   [db _e]
   (-> db
       (tool.handlers/set-state :pan)
       (tool.handlers/set-cursor "grabbing")))
 
-(defmethod tool.hierarchy/on-drag [:pan :pan]
+(defmethod tool.hierarchy/on-drag [::pan :pan]
   [db e]
   (frame.handlers/pan-by db (matrix/sub (:pointer-pos db)
                                         (:pointer-pos e))))
 
-(defmethod tool.hierarchy/on-drag-end [:pan :pan]
+(defmethod tool.hierarchy/on-drag-end [::pan :pan]
   [db _e]
   (-> db
       (tool.handlers/set-state :idle)
@@ -55,6 +56,6 @@
               {:id :tool/pan
                :label [::tool-pan "Pan"]
                :icon "hand"
-               :event [::tool.events/activate :pan]
-               :active [::tool.subs/active? :pan]
+               :event [::tool.events/activate ::pan]
+               :active [::tool.subs/active? ::pan]
                :shortcuts [{:keyCode (utils.key/codes "P")}]}])

--- a/src/renderer/tool/impl/base/transform/clone.cljs
+++ b/src/renderer/tool/impl/base/transform/clone.cljs
@@ -6,19 +6,20 @@
    [renderer.snap.handlers :as snap.handlers]
    [renderer.tool.handlers :as tool.handlers]
    [renderer.tool.hierarchy :as tool.hierarchy]
+   [renderer.tool.impl.base.transform.core :as-alias transform]
    [renderer.tool.impl.base.transform.select :as transform.select]
    [renderer.tool.impl.base.transform.translate :as transform.translate]
    [renderer.utils.bounds :as utils.bounds]
    [renderer.views :as views]))
 
-(defmethod tool.hierarchy/help [:transform :clone]
+(defmethod tool.hierarchy/help [::transform/transform :clone]
   []
   (i18n.views/t [::clone
                  [:div "Hold %1 to restrict direction. or release %2 to move"]]
                 [[views/kbd "Ctrl"]
                  [views/kbd "Alt"]]))
 
-(defmethod tool.hierarchy/on-drag [:transform :clone]
+(defmethod tool.hierarchy/on-drag [::transform/transform :clone]
   [db e]
   (let [{:keys [ctrl-key shift-key alt-key]} e
         delta (tool.handlers/pointer-delta db)]
@@ -32,7 +33,7 @@
           (tool.handlers/set-cursor "copy"))
       (tool.handlers/set-state db :translate))))
 
-(defmethod tool.hierarchy/on-drag-end [:transform :clone]
+(defmethod tool.hierarchy/on-drag-end [::transform/transform :clone]
   [db e]
   (-> db
       (tool.handlers/set-state :idle)
@@ -40,7 +41,7 @@
       (history.handlers/finalize (:timestamp e)
                                  [::clone-selection "Clone selection"])))
 
-(defmethod tool.hierarchy/snapping-points [:transform :clone]
+(defmethod tool.hierarchy/snapping-points [::transform/transform :clone]
   [db]
   (let [selected (element.handlers/selected db)
         options (-> db :snap :options)]
@@ -49,6 +50,6 @@
       (into (utils.bounds/->snapping-points (element.handlers/bbox db)
                                             options)))))
 
-(defmethod tool.hierarchy/snapping-elements [:transform :clone]
+(defmethod tool.hierarchy/snapping-elements [::transform/transform :clone]
   [db]
   (element.handlers/non-selected-visible db))

--- a/src/renderer/tool/impl/base/transform/core.cljs
+++ b/src/renderer/tool/impl/base/transform/core.cljs
@@ -8,6 +8,7 @@
    [renderer.element.db :refer [Element]]
    [renderer.element.handlers :as element.handlers]
    [renderer.element.subs :as-alias element.subs]
+   [renderer.hierarchy :as hierarchy]
    [renderer.tool.events :as-alias tool.events]
    [renderer.tool.hierarchy :as tool.hierarchy]
    [renderer.tool.impl.base.transform.clone]
@@ -23,9 +24,9 @@
    [renderer.utils.length :as utils.length]
    [renderer.utils.svg :as utils.svg]))
 
-(tool.hierarchy/derive! :transform ::tool.hierarchy/tool)
+(hierarchy/derive! ::transform ::tool.hierarchy/tool)
 
-(defmethod tool.hierarchy/on-deactivate :transform
+(defmethod tool.hierarchy/on-deactivate ::transform
   [db]
   (-> db
       (element.handlers/clear-ignored)
@@ -92,7 +93,7 @@
     [utils.svg/label text {:x x
                            :y y}]))
 
-(defmethod tool.hierarchy/render :transform
+(defmethod tool.hierarchy/render ::transform
   []
   (let [state @(rf/subscribe [::tool.subs/state])
         selected-elements @(rf/subscribe [::element.subs/selected])
@@ -125,8 +126,8 @@
               {:id :tool/transform
                :label [::label "Transform"]
                :icon "pointer"
-               :event [::tool.events/activate :transform]
-               :active [::tool.subs/active? :transform]
+               :event [::tool.events/activate ::transform]
+               :active [::tool.subs/active? ::transform]
                :shortcuts [{:keyCode (utils.key/codes "S")}]}])
 
 (rf/reg-global-interceptor

--- a/src/renderer/tool/impl/base/transform/edit.cljs
+++ b/src/renderer/tool/impl/base/transform/edit.cljs
@@ -9,11 +9,12 @@
    [renderer.snap.handlers :as snap.handlers]
    [renderer.tool.handlers :as tool.handlers]
    [renderer.tool.hierarchy :as tool.hierarchy]
+   [renderer.tool.impl.base.transform.core :as-alias transform]
    [renderer.tool.impl.base.transform.translate :as transform.translate]
    [renderer.utils.bounds :as utils.bounds]
    [renderer.views :as views]))
 
-(defmethod tool.hierarchy/help [:transform :edit]
+(defmethod tool.hierarchy/help [::transform/transform :edit]
   []
   (i18n.views/t [::help-edit "Hold %1 to restrict direction."]
                 [[views/kbd "Ctrl"]]))
@@ -29,7 +30,7 @@
                        [(/ delta-x w) (/ delta-y h)])]
     (update db :anchor-offset matrix/add factor-delta)))
 
-(defmethod tool.hierarchy/on-drag [:transform :edit]
+(defmethod tool.hierarchy/on-drag [::transform/transform :edit]
   [db e]
   (let [bbox (element.handlers/bbox db)
         delta (tool.handlers/pointer-delta db)
@@ -39,14 +40,14 @@
         (translate-offset delta axis bbox)
         (snap.handlers/snap-with translate-offset axis bbox))))
 
-(defmethod tool.hierarchy/on-drag-end [:transform :edit]
+(defmethod tool.hierarchy/on-drag-end [::transform/transform :edit]
   [db _e]
   (-> db
       (assoc :anchor-point (:anchor-offset db))
       (tool.handlers/set-state :idle)
       (dissoc :clicked-element :pivot-point)))
 
-(defmethod tool.hierarchy/snapping-points [:transform :edit]
+(defmethod tool.hierarchy/snapping-points [::transform/transform :edit]
   [db]
   (when-let [el (:clicked-element db)]
     [(with-meta
@@ -54,6 +55,6 @@
                    (tool.handlers/pointer-delta db))
        {:label [::pivot-handle "pivot handle"]})]))
 
-(defmethod tool.hierarchy/snapping-elements [:transform :edit]
+(defmethod tool.hierarchy/snapping-elements [::transform/transform :edit]
   [db]
   (element.handlers/selected db))

--- a/src/renderer/tool/impl/base/transform/idle.cljs
+++ b/src/renderer/tool/impl/base/transform/idle.cljs
@@ -9,12 +9,13 @@
    [renderer.tool.db :refer [Handle State]]
    [renderer.tool.handlers :as tool.handlers]
    [renderer.tool.hierarchy :as tool.hierarchy]
+   [renderer.tool.impl.base.transform.core :as-alias transform]
    [renderer.tool.impl.base.transform.select :as transform.select]
    [renderer.utils.element :as utils.element]
    [renderer.utils.key :as utils.key]
    [renderer.views :as views]))
 
-(defmethod tool.hierarchy/on-pointer-move [:transform :idle]
+(defmethod tool.hierarchy/on-pointer-move [::transform/transform :idle]
   [db e]
   (let [{:keys [element]} e
         movable? (or (= (:type element) :handle)
@@ -31,7 +32,7 @@
       (:id element)
       (element.handlers/hover (:id element)))))
 
-(defmethod tool.hierarchy/help [:transform :idle]
+(defmethod tool.hierarchy/help [::transform/transform :idle]
   []
   [:<>
    (i18n.views/t [::idle-click
@@ -41,7 +42,7 @@
                   [:div "Hold %1 to add or remove elements to selection."]]
                  [[views/kbd "⇧"]])])
 
-(defmethod tool.hierarchy/on-pointer-down [:transform :idle]
+(defmethod tool.hierarchy/on-pointer-down [::transform/transform :idle]
   [db e]
   (let [{:keys [button element]} e]
     (cond-> db
@@ -55,7 +56,7 @@
       :always
       (element.handlers/ignore :bbox))))
 
-(defmethod tool.hierarchy/on-pointer-up [:transform :idle]
+(defmethod tool.hierarchy/on-pointer-up [::transform/transform :idle]
   [db e]
   (let [{:keys [element timestamp]} e]
     (-> db
@@ -67,7 +68,7 @@
                                      [::deselect-element "Deselect element"]
                                      [::select-element "Select element"])))))
 
-(defmethod tool.hierarchy/on-double-click [:transform :idle]
+(defmethod tool.hierarchy/on-double-click [::transform/transform :idle]
   [db e]
   (let [{{:keys [tag id]} :element} e]
     (if (= tag :g)
@@ -76,7 +77,7 @@
           (element.handlers/deselect id))
       (cond-> db
         (not= :canvas tag)
-        (tool.handlers/activate :edit)))))
+        (tool.handlers/edit)))))
 
 (m/=> drag-start->state [:-> [:or Element Handle] State])
 (defn drag-start->state
@@ -94,7 +95,7 @@
 
       :idle)))
 
-(defmethod tool.hierarchy/on-drag-start [:transform :idle]
+(defmethod tool.hierarchy/on-drag-start [::transform/transform :idle]
   [db e]
   (let [{:keys [clicked-element state]} db
         {:keys [shift-key]} e
@@ -130,7 +131,7 @@
       "ArrowRight" [arrow-key-step 0]
       [0 0])))
 
-(defmethod tool.hierarchy/on-key-down [:transform :idle]
+(defmethod tool.hierarchy/on-key-down [::transform/transform :idle]
   [db e]
   (let [k (:key e)]
     (cond-> db
@@ -143,7 +144,7 @@
       (= k "Escape")
       (history.handlers/reset-state))))
 
-(defmethod tool.hierarchy/on-key-up [:transform :idle]
+(defmethod tool.hierarchy/on-key-up [::transform/transform :idle]
   [db e]
   (let [k (:key e)]
     (cond-> db

--- a/src/renderer/tool/impl/base/transform/scale.cljs
+++ b/src/renderer/tool/impl/base/transform/scale.cljs
@@ -10,10 +10,11 @@
    [renderer.snap.handlers :as snap.handlers]
    [renderer.tool.handlers :as tool.handlers]
    [renderer.tool.hierarchy :as tool.hierarchy]
+   [renderer.tool.impl.base.transform.core :as-alias transform]
    [renderer.utils.bounds :as utils.bounds]
    [renderer.views :as views]))
 
-(defmethod tool.hierarchy/help [:transform :scale]
+(defmethod tool.hierarchy/help [::transform/transform :scale]
   []
   (i18n.views/t [::scale
                  [:div "Hold %1 to lock proportions, %2 to scale in place,
@@ -133,7 +134,7 @@
       (tool.handlers/multi-touch? db)
       (element.handlers/ratio-locked? db)))
 
-(defmethod tool.hierarchy/on-drag [:transform :scale]
+(defmethod tool.hierarchy/on-drag [::transform/transform :scale]
   [db e]
   (let [{:keys [shift-key alt-key]} e
         delta (tool.handlers/pointer-delta db)
@@ -147,7 +148,7 @@
                 :in-place shift-key
                 :recursive alt-key}))))
 
-(defmethod tool.hierarchy/on-drag-end [:transform :scale]
+(defmethod tool.hierarchy/on-drag-end [::transform/transform :scale]
   [db e]
   (-> db
       (tool.handlers/set-state :idle)
@@ -155,7 +156,7 @@
       (history.handlers/finalize (:timestamp e)
                                  [::scale-selection "Scale selection"])))
 
-(defmethod tool.hierarchy/snapping-points [:transform :scale]
+(defmethod tool.hierarchy/snapping-points [::transform/transform :scale]
   [db]
   (when-let [el (:clicked-element db)]
     [(with-meta
@@ -163,6 +164,6 @@
                    (tool.handlers/pointer-delta db))
        {:label [::scale-handle "scale handle"]})]))
 
-(defmethod tool.hierarchy/snapping-elements [:transform :scale]
+(defmethod tool.hierarchy/snapping-elements [::transform/transform :scale]
   [db]
   (element.handlers/non-selected-visible db))

--- a/src/renderer/tool/impl/base/transform/select.cljs
+++ b/src/renderer/tool/impl/base/transform/select.cljs
@@ -13,11 +13,12 @@
    [renderer.tool.db :refer [Handle]]
    [renderer.tool.handlers :as tool.handlers]
    [renderer.tool.hierarchy :as tool.hierarchy]
+   [renderer.tool.impl.base.transform.core :as-alias transform]
    [renderer.utils.bounds :as utils.bounds]
    [renderer.utils.svg :as utils.svg]
    [renderer.views :as views]))
 
-(defmethod tool.hierarchy/help [:transform :select]
+(defmethod tool.hierarchy/help [::transform/transform :select]
   []
   (i18n.views/t [::select [:div "Hold %1 to select intersecting elements."]]
                 [[views/kbd "Alt"]]))
@@ -85,7 +86,7 @@
     (not intersecting?)
     (assoc-in [:attrs :fill] "transparent")))
 
-(defmethod tool.hierarchy/on-drag [:transform :select]
+(defmethod tool.hierarchy/on-drag [::transform/transform :select]
   [db e]
   (let [{:keys [alt-key]} e]
     (-> db
@@ -93,7 +94,7 @@
         (app.handlers/add-fx [::set-select-box (select-rect db alt-key)])
         (reduce-by-area e element.handlers/hover))))
 
-(defmethod tool.hierarchy/on-drag-end [:transform :select]
+(defmethod tool.hierarchy/on-drag-end [::transform/transform :select]
   [db e]
   (cond-> db
     (not (:shift-key e))
@@ -107,7 +108,7 @@
         (history.handlers/finalize (:timestamp e)
                                    [::modify-selection "Modify selection"]))))
 
-(defmethod tool.hierarchy/snapping-points [:transform :select]
+(defmethod tool.hierarchy/snapping-points [::transform/transform :select]
   [db]
   (let [selected (element.handlers/selected db)
         options (-> db :snap :options)]
@@ -118,6 +119,6 @@
         (into (utils.bounds/->snapping-points (element.handlers/bbox db)
                                               options))))))
 
-(defmethod tool.hierarchy/snapping-elements [:transform :select]
+(defmethod tool.hierarchy/snapping-elements [::transform/transform :select]
   [db]
   (element.handlers/non-selected-visible db))

--- a/src/renderer/tool/impl/base/transform/translate.cljs
+++ b/src/renderer/tool/impl/base/transform/translate.cljs
@@ -11,13 +11,14 @@
    [renderer.snap.handlers :as snap.handlers]
    [renderer.tool.handlers :as tool.handlers]
    [renderer.tool.hierarchy :as tool.hierarchy]
+   [renderer.tool.impl.base.transform.core :as-alias transform]
    [renderer.tool.impl.base.transform.select :as transform.select]
    [renderer.utils.bounds :as utils.bounds]
    [renderer.utils.element :as utils.element]
    [renderer.utils.extra :refer [partial-right]]
    [renderer.views :as views]))
 
-(defmethod tool.hierarchy/help [:transform :translate]
+(defmethod tool.hierarchy/help [::transform/transform :translate]
   []
   (i18n.views/t [::translate
                  [:div "Hold %1 to restrict direction, and %2 to clone."]]
@@ -85,7 +86,7 @@
                                               :hovered-svg hovered-svg
                                               :auto-parent auto-parent?}) db))))
 
-(defmethod tool.hierarchy/on-drag [:transform :translate]
+(defmethod tool.hierarchy/on-drag [::transform/transform :translate]
   [db e]
   (let [{:keys [shift-key ctrl-key alt-key]} e
         delta (tool.handlers/pointer-delta db)
@@ -100,7 +101,7 @@
           (snap.handlers/snap-with translate ctrl-key)
           (tool.handlers/set-cursor (if locked? "not-allowed" "move"))))))
 
-(defmethod tool.hierarchy/on-drag-end [:transform :translate]
+(defmethod tool.hierarchy/on-drag-end [::transform/transform :translate]
   [db e]
   (-> db
       (tool.handlers/set-state :idle)
@@ -108,7 +109,7 @@
       (history.handlers/finalize (:timestamp e)
                                  [::move-selection "Move selection"])))
 
-(defmethod tool.hierarchy/snapping-points [:transform :translate]
+(defmethod tool.hierarchy/snapping-points [::transform/transform :translate]
   [db]
   (let [selected (element.handlers/selected db)
         options (-> db :snap :options)]
@@ -119,6 +120,6 @@
         (into (utils.bounds/->snapping-points (element.handlers/bbox db)
                                               options))))))
 
-(defmethod tool.hierarchy/snapping-elements [:transform :translate]
+(defmethod tool.hierarchy/snapping-elements [::transform/transform :translate]
   [db]
   (element.handlers/non-selected-visible db))

--- a/src/renderer/tool/impl/base/zoom.cljs
+++ b/src/renderer/tool/impl/base/zoom.cljs
@@ -7,6 +7,7 @@
    [renderer.app.handlers :as app.handlers]
    [renderer.element.hierarchy :as element.hierarchy]
    [renderer.frame.handlers :as frame.handlers]
+   [renderer.hierarchy :as hierarchy]
    [renderer.i18n.views :as i18n.views]
    [renderer.snap.handlers :as snap.handlers]
    [renderer.tool.events :as-alias tool.events]
@@ -17,7 +18,7 @@
    [renderer.utils.svg :as utils.svg]
    [renderer.views :as views]))
 
-(tool.hierarchy/derive! :zoom ::tool.hierarchy/tool)
+(hierarchy/derive! ::zoom ::tool.hierarchy/tool)
 
 (defonce select-box (reagent/atom nil))
 
@@ -26,45 +27,45 @@
  (fn [value]
    (reset! select-box value)))
 
-(defmethod tool.hierarchy/help [:zoom :idle]
+(defmethod tool.hierarchy/help [::zoom :idle]
   []
   [:<>
    (i18n.views/t [::zoom-in "Click or select an area to zoom in."])
    (i18n.views/t [::zoom-out "Hold %1 to zoom out."] [[views/kbd "⇧"]])])
 
-(defmethod tool.hierarchy/help [:zoom :select]
+(defmethod tool.hierarchy/help [::zoom :select]
   []
   (i18n.views/t [::release-to-focus "Release to focus on the area."]))
 
-(defmethod tool.hierarchy/on-activate :zoom
+(defmethod tool.hierarchy/on-activate ::zoom
   [db]
   (tool.handlers/set-cursor db "zoom-in"))
 
-(defmethod tool.hierarchy/on-deactivate :zoom
+(defmethod tool.hierarchy/on-deactivate ::zoom
   [db]
   (app.handlers/add-fx db [::set-select-box nil]))
 
-(defmethod tool.hierarchy/on-key-down [:zoom :idle]
+(defmethod tool.hierarchy/on-key-down [::zoom :idle]
   [db e]
   (cond-> db
     (:shift-key e)
     (tool.handlers/set-cursor "zoom-out")))
 
-(defmethod tool.hierarchy/on-key-up [:zoom :idle]
+(defmethod tool.hierarchy/on-key-up [::zoom :idle]
   [db e]
   (cond-> db
     (not (:shift-key e))
     (tool.handlers/set-cursor "zoom-in")))
 
-(defmethod tool.hierarchy/on-drag-start [:zoom :idle]
+(defmethod tool.hierarchy/on-drag-start [::zoom :idle]
   [db _e]
   (tool.handlers/set-state db :select))
 
-(defmethod tool.hierarchy/on-drag [:zoom :select]
+(defmethod tool.hierarchy/on-drag [::zoom :select]
   [db _e]
   (app.handlers/add-fx db [::set-select-box (utils.svg/select-box db)]))
 
-(defmethod tool.hierarchy/on-drag-end [:zoom :select]
+(defmethod tool.hierarchy/on-drag-end [::zoom :select]
   [db e]
   (let [{:keys [dom-rect zoom-sensitivity active-document]} db
         [offset-x offset-y] (:adjusted-pointer-offset db)
@@ -86,7 +87,7 @@
         (snap.handlers/update-viewport-tree)
         (app.handlers/add-fx [::app.effects/persist]))))
 
-(defmethod tool.hierarchy/on-pointer-up [:zoom :idle]
+(defmethod tool.hierarchy/on-pointer-up [::zoom :idle]
   [db e]
   (let [factor (cond->> (:zoom-sensitivity db)
                  (not (:shift-key e))
@@ -96,7 +97,7 @@
         (snap.handlers/update-viewport-tree)
         (app.handlers/add-fx [::app.effects/persist]))))
 
-(defmethod tool.hierarchy/render :zoom
+(defmethod tool.hierarchy/render ::zoom
   []
   [element.hierarchy/render @select-box])
 
@@ -104,6 +105,6 @@
               {:id :tool/zoom
                :label [::tool-zoom "Zoom"]
                :icon "magnifier"
-               :event [::tool.events/activate :zoom]
-               :active [::tool.subs/active? :zoom]
+               :event [::tool.events/activate ::zoom]
+               :active [::tool.subs/active? ::zoom]
                :shortcuts [{:keyCode (utils.key/codes "Z")}]}])

--- a/src/renderer/tool/impl/draw/brush.cljs
+++ b/src/renderer/tool/impl/draw/brush.cljs
@@ -10,6 +10,7 @@
    [renderer.document.handlers :as document.handlers]
    [renderer.element.handlers :as element.handlers]
    [renderer.element.hierarchy :as element.hierarchy]
+   [renderer.hierarchy :as hierarchy]
    [renderer.history.handlers :as history.handlers]
    [renderer.tool.events :as-alias tool.events]
    [renderer.tool.handlers :as tool.handlers]
@@ -17,7 +18,7 @@
    [renderer.tool.subs :as-alias tool.subs]
    [renderer.utils.key :as utils.key]))
 
-(tool.hierarchy/derive! :brush ::tool.hierarchy/draw)
+(hierarchy/derive! ::brush ::tool.hierarchy/draw)
 
 (defonce brush (reagent/atom nil))
 
@@ -26,7 +27,7 @@
  (fn [value]
    (reset! brush value)))
 
-(defmethod tool.hierarchy/on-pointer-move [:brush :idle]
+(defmethod tool.hierarchy/on-pointer-move [::brush :idle]
   [db e]
   (let [[x y] (:adjusted-pointer-pos db)
         pressure (:pressure e)
@@ -40,7 +41,7 @@
                                                   :r r
                                                   :fill stroke}}])))
 
-(defmethod tool.hierarchy/on-drag-start [:brush :idle]
+(defmethod tool.hierarchy/on-drag-start [::brush :idle]
   [db e]
   (let [point (string/join " " (conj (:adjusted-pointer-pos db) (:pressure e)))
         stroke (document.handlers/attr db :stroke)]
@@ -55,7 +56,7 @@
                                        :smoothing 0.5
                                        :streamline 0.5}}))))
 
-(defmethod tool.hierarchy/on-drag [:brush :create]
+(defmethod tool.hierarchy/on-drag [::brush :create]
   [db e]
   (let [[min-x min-y] (element.handlers/parent-offset db)
         point (matrix/sub (:adjusted-pointer-pos db) [min-x min-y])
@@ -64,13 +65,13 @@
                                       update-in [:attrs :points]
                                       str " " point)))
 
-(defmethod tool.hierarchy/on-drag-end [:brush :create]
+(defmethod tool.hierarchy/on-drag-end [::brush :create]
   [db e]
   (-> db
       (history.handlers/finalize (:timestamp e) [::draw-brush "Draw brush"])
-      (tool.handlers/activate :transform)))
+      (tool.handlers/deactivate)))
 
-(defmethod tool.hierarchy/render :brush
+(defmethod tool.hierarchy/render ::brush
   []
   (when-not (= :create @(rf/subscribe [::tool.subs/state]))
     [element.hierarchy/render @brush]))
@@ -79,6 +80,6 @@
               {:id :tool/brush
                :label [::label "Brush"]
                :icon "brush"
-               :event [::tool.events/activate :brush]
-               :active [::tool.subs/active? :brush]
+               :event [::tool.events/activate ::brush]
+               :active [::tool.subs/active? ::brush]
                :shortcuts [{:keyCode (utils.key/codes "B")}]}])

--- a/src/renderer/tool/impl/draw/core.cljs
+++ b/src/renderer/tool/impl/draw/core.cljs
@@ -2,13 +2,14 @@
   (:require
    [re-frame.core :as rf]
    [renderer.action.events :as-alias action.events]
+   [renderer.hierarchy :as hierarchy]
    [renderer.i18n.views :as i18n.views]
    [renderer.tool.handlers :as tool.handlers]
    [renderer.tool.hierarchy :as tool.hierarchy]
    [renderer.tool.impl.draw.brush]
    [renderer.tool.impl.draw.pencil]))
 
-(tool.hierarchy/derive! ::tool.hierarchy/draw ::tool.hierarchy/tool)
+(hierarchy/derive! ::tool.hierarchy/draw ::tool.hierarchy/tool)
 
 (defmethod tool.hierarchy/help [::tool.hierarchy/draw :idle]
   []

--- a/src/renderer/tool/impl/draw/pencil.cljs
+++ b/src/renderer/tool/impl/draw/pencil.cljs
@@ -6,6 +6,7 @@
    [renderer.action.events :as-alias action.events]
    [renderer.document.handlers :as document.handlers]
    [renderer.element.handlers :as element.handlers]
+   [renderer.hierarchy :as hierarchy]
    [renderer.history.handlers :as history.handlers]
    [renderer.tool.events :as-alias tool.events]
    [renderer.tool.handlers :as tool.handlers]
@@ -14,9 +15,9 @@
    [renderer.utils.element :as utils.element]
    [renderer.utils.path :as utils.path]))
 
-(tool.hierarchy/derive! :pencil ::tool.hierarchy/draw)
+(hierarchy/derive! ::pencil ::tool.hierarchy/draw)
 
-(defmethod tool.hierarchy/on-drag-start [:pencil :idle]
+(defmethod tool.hierarchy/on-drag-start [::pencil :idle]
   [db _e]
   (let [stroke (document.handlers/attr db :stroke)
         point-1 (string/join " " (:adjusted-pointer-offset db))
@@ -29,7 +30,7 @@
                                        :stroke stroke
                                        :fill "transparent"}}))))
 
-(defmethod tool.hierarchy/on-drag [:pencil :create]
+(defmethod tool.hierarchy/on-drag [::pencil :create]
   [db _e]
   (let [[min-x min-y] (element.handlers/parent-offset db)
         point (matrix/sub (:adjusted-pointer-pos db) [min-x min-y])
@@ -38,7 +39,7 @@
                                       update-in [:attrs :points]
                                       str " " point)))
 
-(defmethod tool.hierarchy/on-drag-end [:pencil :create]
+(defmethod tool.hierarchy/on-drag-end [::pencil :create]
   [db e]
   (let [path (-> (first (element.handlers/selected db))
                  (utils.element/->path)
@@ -47,11 +48,11 @@
     (-> db
         (element.handlers/swap path)
         (history.handlers/finalize (:timestamp e) [::draw-line "Draw line"])
-        (tool.handlers/activate :transform))))
+        (tool.handlers/deactivate))))
 
 (rf/dispatch [::action.events/register-action
               {:id :tool/pencil
                :label [::label "Pen"]
                :icon "pencil"
-               :event [::tool.events/activate :pencil]
-               :active [::tool.subs/active? :pencil]}])
+               :event [::tool.events/activate ::pencil]
+               :active [::tool.subs/active? ::pencil]}])

--- a/src/renderer/tool/impl/element/circle.cljs
+++ b/src/renderer/tool/impl/element/circle.cljs
@@ -6,6 +6,7 @@
    [renderer.action.events :as-alias action.events]
    [renderer.document.handlers :as document.handlers]
    [renderer.element.handlers :as element.handlers]
+   [renderer.hierarchy :as hierarchy]
    [renderer.history.handlers :as history.handlers]
    [renderer.tool.events :as-alias tool.events]
    [renderer.tool.handlers :as tool.handlers]
@@ -14,9 +15,9 @@
    [renderer.utils.key :as utils.key]
    [renderer.utils.length :as utils.length]))
 
-(tool.hierarchy/derive! :circle ::tool.hierarchy/element)
+(hierarchy/derive! ::circle ::tool.hierarchy/element)
 
-(defmethod tool.hierarchy/on-drag-start [:circle :idle]
+(defmethod tool.hierarchy/on-drag-start [::circle :idle]
   [db _e]
   (let [offset (tool.handlers/snapped-offset db)
         position (tool.handlers/snapped-position db)
@@ -34,21 +35,21 @@
                                        :stroke stroke
                                        :r radius}}))))
 
-(defmethod tool.hierarchy/on-drag [:circle :create]
+(defmethod tool.hierarchy/on-drag [::circle :create]
   [db _e]
   (let [offset (tool.handlers/snapped-offset db)
         position (tool.handlers/snapped-position db)
         radius (utils.length/->fixed (matrix/distance position offset))]
     (element.handlers/update-selected db #(assoc-in % [:attrs :r] radius))))
 
-(defmethod tool.hierarchy/on-drag-end [:circle :create]
+(defmethod tool.hierarchy/on-drag-end [::circle :create]
   [db e]
   (-> db
       (history.handlers/finalize (:timestamp e)
                                  [::create-circle "Create circle"])
-      (tool.handlers/activate :transform)))
+      (tool.handlers/deactivate)))
 
-(defmethod tool.hierarchy/snapping-points [:circle :create]
+(defmethod tool.hierarchy/snapping-points [::circle :create]
   [db]
   [(with-meta
      (:adjusted-pointer-pos db)
@@ -60,6 +61,6 @@
               {:id :tool/circle
                :label [::label "Circle"]
                :icon "circle-tool"
-               :event [::tool.events/activate :circle]
-               :active [::tool.subs/active? :circle]
+               :event [::tool.events/activate ::circle]
+               :active [::tool.subs/active? ::circle]
                :shortcuts [{:keyCode (utils.key/codes "C")}]}])

--- a/src/renderer/tool/impl/element/core.cljs
+++ b/src/renderer/tool/impl/element/core.cljs
@@ -3,6 +3,7 @@
    [re-frame.core :as rf]
    [renderer.action.events :as-alias action.events]
    [renderer.element.handlers :as element.handlers]
+   [renderer.hierarchy :as hierarchy]
    [renderer.i18n.views :as i18n.views]
    [renderer.tool.handlers :as tool.handlers]
    [renderer.tool.hierarchy :as tool.hierarchy]
@@ -17,7 +18,7 @@
    [renderer.tool.impl.element.svg]
    [renderer.tool.impl.element.text]))
 
-(tool.hierarchy/derive! ::tool.hierarchy/element ::tool.hierarchy/tool)
+(hierarchy/derive! ::tool.hierarchy/element ::tool.hierarchy/tool)
 
 (defmethod tool.hierarchy/help [::tool.hierarchy/element :idle]
   []

--- a/src/renderer/tool/impl/element/ellipse.cljs
+++ b/src/renderer/tool/impl/element/ellipse.cljs
@@ -5,6 +5,7 @@
    [renderer.action.events :as-alias action.events]
    [renderer.document.handlers :as document.handlers]
    [renderer.element.handlers :as element.handlers]
+   [renderer.hierarchy :as hierarchy]
    [renderer.history.handlers :as history.handlers]
    [renderer.i18n.views :as i18n.views]
    [renderer.tool.events :as-alias tool.events]
@@ -14,9 +15,9 @@
    [renderer.utils.length :as utils.length]
    [renderer.views :as views]))
 
-(tool.hierarchy/derive! :ellipse ::tool.hierarchy/element)
+(hierarchy/derive! ::ellipse ::tool.hierarchy/element)
 
-(defmethod tool.hierarchy/help [:ellipse :create]
+(defmethod tool.hierarchy/help [::ellipse :create]
   []
   (i18n.views/t [::help [:div "Hold %1 to lock proportions."]]
                 [[views/kbd "Ctrl"]]))
@@ -30,7 +31,7 @@
     {:rx (utils.length/->fixed (cond-> rx lock-ratio (min ry)))
      :ry (utils.length/->fixed (cond-> ry lock-ratio (min rx)))}))
 
-(defmethod tool.hierarchy/on-drag-start [:ellipse :idle]
+(defmethod tool.hierarchy/on-drag-start [::ellipse :idle]
   [db e]
   (let [[x y] (tool.handlers/snapped-position db)
         fill (document.handlers/attr db :fill)
@@ -45,23 +46,23 @@
                                               :fill fill
                                               :stroke stroke})}))))
 
-(defmethod tool.hierarchy/on-drag [:ellipse :create]
+(defmethod tool.hierarchy/on-drag [::ellipse :create]
   [db e]
   (let [lock-ratio (or (:ctrl-key e) (tool.handlers/multi-touch? db))
         attrs (attributes db lock-ratio)
         assoc-attr (fn [el [k v]] (assoc-in el [:attrs k] (str v)))]
     (element.handlers/update-selected db #(reduce assoc-attr % attrs))))
 
-(defmethod tool.hierarchy/on-drag-end [:ellipse :create]
+(defmethod tool.hierarchy/on-drag-end [::ellipse :create]
   [db e]
   (-> db
       (history.handlers/finalize (:timestamp e)
                                  [::create-ellipse "Create ellipse"])
-      (tool.handlers/activate :transform)))
+      (tool.handlers/deactivate)))
 
 (rf/dispatch [::action.events/register-action
               {:id :tool/ellipse
                :label [::label "Ellipse"]
                :icon "ellipse-tool"
-               :event [::tool.events/activate :ellipse]
-               :active [::tool.subs/active? :ellipse]}])
+               :event [::tool.events/activate ::ellipse]
+               :active [::tool.subs/active? ::ellipse]}])

--- a/src/renderer/tool/impl/element/image.cljs
+++ b/src/renderer/tool/impl/element/image.cljs
@@ -9,19 +9,20 @@
    [renderer.element.db :as element.db]
    [renderer.element.effects :as-alias element.effects]
    [renderer.element.events :as-alias element.events]
+   [renderer.hierarchy :as hierarchy]
    [renderer.tool.events :as-alias tool.events]
    [renderer.tool.handlers :as tool.handlers]
    [renderer.tool.hierarchy :as tool.hierarchy]
    [renderer.tool.subs :as-alias tool.subs]
    [renderer.utils.key :as utils.key]))
 
-(tool.hierarchy/derive! :image ::tool.hierarchy/element)
+(hierarchy/derive! ::image ::tool.hierarchy/element)
 
-(defmethod tool.hierarchy/on-drag-end [:image :idle]
+(defmethod tool.hierarchy/on-drag-end [::image :idle]
   [db e]
   (tool.hierarchy/on-pointer-up db e))
 
-(defmethod tool.hierarchy/on-pointer-up [:image :idle]
+(defmethod tool.hierarchy/on-pointer-up [::image :idle]
   [db _e]
   (app.handlers/add-fx
    db
@@ -35,7 +36,7 @@
 (rf/reg-event-fx
  ::success
  (fn [{:keys [db]} [_ _file-handle file]]
-   {:db (tool.handlers/activate db :transform)
+   {:db (tool.handlers/deactivate db)
     ::element.effects/import-image
     {:file file
      :on-success [::element.events/add]
@@ -47,6 +48,6 @@
               {:id :tool/image
                :label [::label "Image"]
                :icon "image"
-               :event [::tool.events/activate :image]
-               :active [::tool.subs/active? :image]
+               :event [::tool.events/activate ::image]
+               :active [::tool.subs/active? ::image]
                :shortcuts [{:keyCode (utils.key/codes "I")}]}])

--- a/src/renderer/tool/impl/element/line.cljs
+++ b/src/renderer/tool/impl/element/line.cljs
@@ -6,6 +6,7 @@
    [renderer.action.events :as-alias action.events]
    [renderer.document.handlers :as document.handlers]
    [renderer.element.handlers :as element.handlers]
+   [renderer.hierarchy :as hierarchy]
    [renderer.history.handlers :as history.handlers]
    [renderer.tool.events :as-alias tool.events]
    [renderer.tool.handlers :as tool.handlers]
@@ -14,9 +15,9 @@
    [renderer.utils.key :as utils.key]
    [renderer.utils.length :as utils.length]))
 
-(tool.hierarchy/derive! :line ::tool.hierarchy/element)
+(hierarchy/derive! ::line ::tool.hierarchy/element)
 
-(defmethod tool.hierarchy/on-drag-start [:line :idle]
+(defmethod tool.hierarchy/on-drag-start [::line :idle]
   [db _e]
   (let [[offset-x offset-y] (tool.handlers/snapped-offset db)
         [x y] (tool.handlers/snapped-position db)
@@ -31,7 +32,7 @@
                                        :y2 y
                                        :stroke stroke}}))))
 
-(defmethod tool.hierarchy/on-drag [:line :create]
+(defmethod tool.hierarchy/on-drag [::line :create]
   [db _e]
   (let [position (tool.handlers/snapped-position db)
         [min-x min-y] (element.handlers/parent-offset db)
@@ -42,16 +43,16 @@
                                               (assoc-in [:attrs :x2] x)
                                               (assoc-in [:attrs :y2] y)))))
 
-(defmethod tool.hierarchy/on-drag-end [:line :create]
+(defmethod tool.hierarchy/on-drag-end [::line :create]
   [db e]
   (-> db
       (history.handlers/finalize (:timestamp e) [::create-line "Create line"])
-      (tool.handlers/activate :transform)))
+      (tool.handlers/deactivate)))
 
 (rf/dispatch [::action.events/register-action
               {:id :tool/line
                :label [::label "Line"]
                :icon "line-tool"
-               :event [::tool.events/activate :line]
-               :active [::tool.subs/active? :line]
+               :event [::tool.events/activate ::line]
+               :active [::tool.subs/active? ::line]
                :shortcuts [{:keyCode (utils.key/codes "L")}]}])

--- a/src/renderer/tool/impl/element/poly.cljs
+++ b/src/renderer/tool/impl/element/poly.cljs
@@ -3,14 +3,14 @@
   (:require
    [clojure.core.matrix :as matrix]
    [clojure.string :as string]
-   [renderer.document.handlers :as document.handlers]
    [renderer.element.handlers :as element.handlers]
+   [renderer.hierarchy :as hierarchy]
    [renderer.i18n.views :as i18n.views]
    [renderer.tool.handlers :as tool.handlers]
    [renderer.tool.hierarchy :as tool.hierarchy]
    [renderer.utils.attribute :as utils.attribute]))
 
-(tool.hierarchy/derive! ::tool.hierarchy/poly ::tool.hierarchy/element)
+(hierarchy/derive! ::tool.hierarchy/poly ::tool.hierarchy/element)
 
 (defmethod tool.hierarchy/help [::tool.hierarchy/poly :idle]
   []
@@ -24,18 +24,6 @@
                         "Right click or double click to finalize the
                          shape."])]])
 
-(defn create-el
-  [db initial-point]
-  (let [stroke (document.handlers/attr db :stroke)
-        fill (document.handlers/attr db :fill)]
-    (-> db
-        (tool.handlers/set-state :create)
-        (element.handlers/add {:type :element
-                               :tag (:tool db)
-                               :attrs {:points (string/join " " initial-point)
-                                       :stroke stroke
-                                       :fill fill}}))))
-
 (defn drop-last-point
   [db]
   (element.handlers/update-selected db
@@ -48,11 +36,6 @@
 (defn adjusted-point
   [db point]
   (matrix/sub point (element.handlers/parent-offset db)))
-
-(defmethod tool.hierarchy/on-pointer-up [::tool.hierarchy/poly :idle]
-  [db _e]
-  (->> (tool.handlers/snapped-position db)
-       (create-el db)))
 
 (defmethod tool.hierarchy/on-pointer-up [::tool.hierarchy/poly :create]
   [db _e]

--- a/src/renderer/tool/impl/element/polygon.cljs
+++ b/src/renderer/tool/impl/element/polygon.cljs
@@ -1,8 +1,12 @@
 (ns renderer.tool.impl.element.polygon
   "https://www.w3.org/TR/SVG/shapes.html#PolygonElement"
   (:require
+   [clojure.string :as string]
    [re-frame.core :as rf]
    [renderer.action.events :as-alias action.events]
+   [renderer.document.handlers :as document.handlers]
+   [renderer.element.handlers :as element.handlers]
+   [renderer.hierarchy :as hierarchy]
    [renderer.history.handlers :as history.handlers]
    [renderer.tool.events :as-alias tool.events]
    [renderer.tool.handlers :as tool.handlers]
@@ -10,19 +14,32 @@
    [renderer.tool.impl.element.poly :as poly]
    [renderer.tool.subs :as-alias tool.subs]))
 
-(tool.hierarchy/derive! :polygon ::tool.hierarchy/poly)
+(hierarchy/derive! ::polygon ::tool.hierarchy/poly)
 
-(defmethod tool.hierarchy/on-double-click [:polygon :create]
+(defmethod tool.hierarchy/on-double-click [::polygon :create]
   [db e]
   (-> db
       (poly/drop-last-point)
       (history.handlers/finalize (:timestamp e)
                                  [::create-polygon "Create polygon"])
-      (tool.handlers/activate :transform)))
+      (tool.handlers/deactivate)))
+
+(defmethod tool.hierarchy/on-pointer-up [::polygon :idle]
+  [db _e]
+  (let [stroke (document.handlers/attr db :stroke)
+        fill (document.handlers/attr db :fill)
+        initial-point (tool.handlers/snapped-position db)]
+    (-> db
+        (tool.handlers/set-state :create)
+        (element.handlers/add {:type :element
+                               :tag :polygon
+                               :attrs {:points (string/join " " initial-point)
+                                       :stroke stroke
+                                       :fill fill}}))))
 
 (rf/dispatch [::action.events/register-action
               {:id :tool/polygon
                :label [::label "Polygon"]
                :icon "polygon-tool"
-               :event [::tool.events/activate :polygon]
-               :active [::tool.subs/active? :polygon]}])
+               :event [::tool.events/activate ::polygon]
+               :active [::tool.subs/active? ::polygon]}])

--- a/src/renderer/tool/impl/element/polyline.cljs
+++ b/src/renderer/tool/impl/element/polyline.cljs
@@ -1,8 +1,12 @@
 (ns renderer.tool.impl.element.polyline
   "https://www.w3.org/TR/SVG/shapes.html#PolylineElement"
   (:require
+   [clojure.string :as string]
    [re-frame.core :as rf]
    [renderer.action.events :as-alias action.events]
+   [renderer.document.handlers :as document.handlers]
+   [renderer.element.handlers :as element.handlers]
+   [renderer.hierarchy :as hierarchy]
    [renderer.history.handlers :as history.handlers]
    [renderer.tool.events :as-alias tool.events]
    [renderer.tool.handlers :as tool.handlers]
@@ -10,19 +14,32 @@
    [renderer.tool.impl.element.poly :as poly]
    [renderer.tool.subs :as-alias tool.subs]))
 
-(tool.hierarchy/derive! :polyline ::tool.hierarchy/poly)
+(hierarchy/derive! ::polyline ::tool.hierarchy/poly)
 
-(defmethod tool.hierarchy/on-double-click [:polyline :create]
+(defmethod tool.hierarchy/on-double-click [::polyline :create]
   [db e]
   (-> db
       (poly/drop-last-point)
       (history.handlers/finalize (:timestamp e)
                                  [::create-polyline "Create polyline"])
-      (tool.handlers/activate :transform)))
+      (tool.handlers/deactivate)))
+
+(defmethod tool.hierarchy/on-pointer-up [::polyline :idle]
+  [db _e]
+  (let [stroke (document.handlers/attr db :stroke)
+        fill (document.handlers/attr db :fill)
+        initial-point (tool.handlers/snapped-position db)]
+    (-> db
+        (tool.handlers/set-state :create)
+        (element.handlers/add {:type :element
+                               :tag :polyline
+                               :attrs {:points (string/join " " initial-point)
+                                       :stroke stroke
+                                       :fill fill}}))))
 
 (rf/dispatch [::action.events/register-action
               {:id :tool/polyline
                :label [::label "Polyline"]
                :icon "polyline"
-               :event [::tool.events/activate :polyline]
-               :active [::tool.subs/active? :polyline]}])
+               :event [::tool.events/activate ::polyline]
+               :active [::tool.subs/active? ::polyline]}])

--- a/src/renderer/tool/impl/element/rect.cljs
+++ b/src/renderer/tool/impl/element/rect.cljs
@@ -5,6 +5,7 @@
    [renderer.action.events :as-alias action.events]
    [renderer.document.handlers :as document.handlers]
    [renderer.element.handlers :as element.handlers]
+   [renderer.hierarchy :as hierarchy]
    [renderer.history.handlers :as history.handlers]
    [renderer.i18n.views :as i18n.views]
    [renderer.tool.events :as-alias tool.events]
@@ -15,9 +16,9 @@
    [renderer.utils.length :as utils.length]
    [renderer.views :as views]))
 
-(tool.hierarchy/derive! :rect ::tool.hierarchy/element)
+(hierarchy/derive! ::rect ::tool.hierarchy/element)
 
-(defmethod tool.hierarchy/help [:rect :create]
+(defmethod tool.hierarchy/help [::rect :create]
   []
   (i18n.views/t [::help [:div "Hold %1 to lock proportions."]]
                 [[views/kbd "Ctrl"]]))
@@ -35,7 +36,7 @@
      :width (utils.length/->fixed width)
      :height (utils.length/->fixed height)}))
 
-(defmethod tool.hierarchy/on-drag-start [:rect :idle]
+(defmethod tool.hierarchy/on-drag-start [::rect :idle]
   [db e]
   (let [fill (document.handlers/attr db :fill)
         stroke (document.handlers/attr db :stroke)]
@@ -47,7 +48,7 @@
                                              {:fill fill
                                               :stroke stroke})}))))
 
-(defmethod tool.hierarchy/on-drag [:rect :create]
+(defmethod tool.hierarchy/on-drag [::rect :create]
   [db e]
   (let [lock-ratio (or (:ctrl-key e) (tool.handlers/multi-touch? db))
         attrs (attributes db lock-ratio)
@@ -57,17 +58,17 @@
         (element.handlers/update-selected #(reduce assoc-attr % attrs))
         (element.handlers/translate [(- min-x) (- min-y)]))))
 
-(defmethod tool.hierarchy/on-drag-end [:rect :create]
+(defmethod tool.hierarchy/on-drag-end [::rect :create]
   [db e]
   (-> db
       (history.handlers/finalize (:timestamp e)
                                  [::create-rectangle "Create rectangle"])
-      (tool.handlers/activate :transform)))
+      (tool.handlers/deactivate)))
 
 (rf/dispatch [::action.events/register-action
               {:id :tool/rect
                :label [::label "Rectangle"]
                :icon "rectangle-tool"
-               :event [::tool.events/activate :rect]
-               :active [::tool.subs/active? :rect]
+               :event [::tool.events/activate ::rect]
+               :active [::tool.subs/active? ::rect]
                :shortcuts [{:keyCode (utils.key/codes "R")}]}])

--- a/src/renderer/tool/impl/element/svg.cljs
+++ b/src/renderer/tool/impl/element/svg.cljs
@@ -4,6 +4,7 @@
    [re-frame.core :as rf]
    [renderer.action.events :as-alias action.events]
    [renderer.element.handlers :as element.handlers]
+   [renderer.hierarchy :as hierarchy]
    [renderer.history.handlers :as history.handlers]
    [renderer.i18n.views :as i18n.views]
    [renderer.tool.events :as-alias tool.events]
@@ -14,9 +15,9 @@
    [renderer.utils.length :as utils.length]
    [renderer.views :as views]))
 
-(tool.hierarchy/derive! :svg ::tool.hierarchy/element)
+(hierarchy/derive! ::svg ::tool.hierarchy/element)
 
-(defmethod tool.hierarchy/help [:svg :create]
+(defmethod tool.hierarchy/help [::svg :create]
   []
   (i18n.views/t [::help [:div "Hold %1 to lock proportions."]]
                 [[views/kbd "Ctrl"]]))
@@ -34,7 +35,7 @@
      :width (utils.length/->fixed width)
      :height (utils.length/->fixed height)}))
 
-(defmethod tool.hierarchy/on-drag-start [:svg :idle]
+(defmethod tool.hierarchy/on-drag-start [::svg :idle]
   [db e]
   (-> db
       (tool.handlers/set-state :create)
@@ -42,23 +43,23 @@
                              :type :element
                              :attrs (attributes db (:ctrl-key e))})))
 
-(defmethod tool.hierarchy/on-drag [:svg :create]
+(defmethod tool.hierarchy/on-drag [::svg :create]
   [db e]
   (let [lock-ratio (or (:ctrl-key e) (tool.handlers/multi-touch? db))
         attrs (attributes db lock-ratio)
         assoc-attr (fn [el [k v]] (assoc-in el [:attrs k] (str v)))]
     (element.handlers/update-selected db #(reduce assoc-attr % attrs))))
 
-(defmethod tool.hierarchy/on-drag-end [:svg :create]
+(defmethod tool.hierarchy/on-drag-end [::svg :create]
   [db e]
   (-> db
       (history.handlers/finalize (:timestamp e) [::create-svg "Create SVG"])
-      (tool.handlers/activate :transform)))
+      (tool.handlers/deactivate)))
 
 (rf/dispatch [::action.events/register-action
               {:id :tool/svg
                :label [::label "Svg"]
                :icon "svg"
-               :event [::tool.events/activate :svg]
-               :active [::tool.subs/active? :svg]
+               :event [::tool.events/activate ::svg]
+               :active [::tool.subs/active? ::svg]
                :shortcuts [{:keyCode (utils.key/codes "S")}]}])

--- a/src/renderer/tool/impl/element/text.cljs
+++ b/src/renderer/tool/impl/element/text.cljs
@@ -3,6 +3,7 @@
    [re-frame.core :as rf]
    [renderer.action.events :as-alias action.events]
    [renderer.element.handlers :as element.handlers]
+   [renderer.hierarchy :as hierarchy]
    [renderer.i18n.views :as i18n.views]
    [renderer.tool.events :as-alias tool.events]
    [renderer.tool.handlers :as tool.handlers]
@@ -10,17 +11,17 @@
    [renderer.tool.subs :as-alias tool.subs]
    [renderer.utils.key :as utils.key]))
 
-(tool.hierarchy/derive! :text ::tool.hierarchy/element)
+(hierarchy/derive! ::text ::tool.hierarchy/element)
 
-(defmethod tool.hierarchy/help [:text :idle]
+(defmethod tool.hierarchy/help [::text :idle]
   []
   (i18n.views/t [::help "Click to start typing."]))
 
-(defmethod tool.hierarchy/on-activate :text
+(defmethod tool.hierarchy/on-activate ::text
   [db]
   (tool.handlers/set-cursor db "text"))
 
-(defmethod tool.hierarchy/on-pointer-up [:text :idle]
+(defmethod tool.hierarchy/on-pointer-up [::text :idle]
   [db _e]
   (let [[offset-x offset-y] (tool.handlers/snapped-offset db)
         el {:type :element
@@ -31,9 +32,9 @@
         (element.handlers/deselect)
         (element.handlers/add el)
         (tool.handlers/set-state :type)
-        (tool.handlers/activate :edit))))
+        (tool.handlers/edit))))
 
-(defmethod tool.hierarchy/on-drag-end [:text :idle]
+(defmethod tool.hierarchy/on-drag-end [::text :idle]
   [db e]
   (tool.hierarchy/on-pointer-up db e))
 
@@ -41,6 +42,6 @@
               {:id :tool/text
                :label [::label "Text"]
                :icon "text"
-               :event [::tool.events/activate :text]
-               :active [::tool.subs/active? :text]
+               :event [::tool.events/activate ::text]
+               :active [::tool.subs/active? ::text]
                :shortcuts [{:keyCode (utils.key/codes "T")}]}])

--- a/src/renderer/tool/impl/extension/blob.cljs
+++ b/src/renderer/tool/impl/extension/blob.cljs
@@ -4,12 +4,13 @@
    [clojure.core.matrix :as matrix]
    [renderer.document.handlers :as document.handlers]
    [renderer.element.handlers :as element.handlers]
+   [renderer.hierarchy :as hierarchy]
    [renderer.history.handlers :as history.handlers]
    [renderer.tool.handlers :as tool.handlers]
    [renderer.tool.hierarchy :as tool.hierarchy]
    [renderer.utils.length :as utils.length]))
 
-(tool.hierarchy/derive! :blob ::tool.hierarchy/element)
+(hierarchy/derive! ::blob ::tool.hierarchy/element)
 
 (defn pointer-delta
   [db]
@@ -24,7 +25,7 @@
      :y (utils.length/->fixed (- offset-y radius))
      :size (utils.length/->fixed (* radius 2))}))
 
-(defmethod tool.hierarchy/on-drag-start [:blob :idle]
+(defmethod tool.hierarchy/on-drag-start [::blob :idle]
   [db _e]
   (let [fill (document.handlers/attr db :fill)
         stroke (document.handlers/attr db :stroke)
@@ -39,7 +40,7 @@
                                               :fill fill
                                               :stroke stroke})}))))
 
-(defmethod tool.hierarchy/on-drag [:blob :create]
+(defmethod tool.hierarchy/on-drag [::blob :create]
   [db _e]
   (let [attrs (attributes db)
         assoc-attr (fn [el [k v]] (assoc-in el [:attrs k] (str v)))
@@ -48,8 +49,8 @@
         (element.handlers/update-selected #(reduce assoc-attr % attrs))
         (element.handlers/translate [(- min-x) (- min-y)]))))
 
-(defmethod tool.hierarchy/on-drag-end [:blob :create]
+(defmethod tool.hierarchy/on-drag-end [::blob :create]
   [db e]
   (-> db
       (history.handlers/finalize (:timestamp e) [::create-blob "Create blob"])
-      (tool.handlers/activate :transform)))
+      (tool.handlers/deactivate)))

--- a/src/renderer/tool/impl/misc/dropper.cljs
+++ b/src/renderer/tool/impl/misc/dropper.cljs
@@ -9,6 +9,7 @@
    [renderer.document.handlers :as document.handlers]
    [renderer.effects :as-alias effects]
    [renderer.element.handlers :as element.handlers]
+   [renderer.hierarchy :as hierarchy]
    [renderer.history.handlers :as history.handlers]
    [renderer.i18n.views :as i18n.views]
    [renderer.tool.events :as-alias tool.events]
@@ -17,19 +18,19 @@
    [renderer.tool.subs :as-alias tool.subs]
    [renderer.utils.key :as utils.key]))
 
-(tool.hierarchy/derive! :eye-dropper ::tool.hierarchy/tool)
+(hierarchy/derive! ::eye-dropper ::tool.hierarchy/tool)
 
-(defmethod tool.hierarchy/help [:eye-dropper :idle]
+(defmethod tool.hierarchy/help [::eye-dropper :idle]
   []
   (i18n.views/t [::help "Click anywhere to pick a color."]))
 
-(defmethod tool.hierarchy/on-activate :eye-dropper
+(defmethod tool.hierarchy/on-activate ::eye-dropper
   [db]
   (if (contains? (:features db) :eye-dropper)
     (app.handlers/add-fx db [::effects/eye-dropper {:on-success [::success]
                                                     :on-error [::error]}])
     (-> db
-        (tool.handlers/activate :transform)
+        (tool.handlers/deactivate)
         (app.handlers/add-fx [::app.effects/toast
                               [:error ["Eye Dropper is not available in this
                                         environment."]]]))))
@@ -43,20 +44,20 @@
               (document.handlers/assoc-attr :fill srgb-color)
               (element.handlers/assoc-attr :fill srgb-color)
               (history.handlers/finalize now [::pick-color "Pick color"])
-              (tool.handlers/activate :transform)))}))
+              (tool.handlers/deactivate)))}))
 
 (rf/reg-event-db
  ::error
  (fn [db [_ error]]
    (-> db
-       (tool.handlers/activate :transform)
+       (tool.handlers/deactivate)
        (app.handlers/add-fx [:dispatch [::app.events/toast-error error]]))))
 
 (rf/dispatch [::action.events/register-action
               {:id :tool/eye-dropper
                :label [::label "Eyedropper"]
                :icon "eye-dropper"
-               :event [::tool.events/activate :eye-dropper]
-               :active [::tool.subs/active? :eye-dropper]
+               :event [::tool.events/activate ::eye-dropper]
+               :active [::tool.subs/active? ::eye-dropper]
                :available [::app.subs/supported-feature? :eye-dropper]
                :shortcuts [{:keyCode (utils.key/codes "D")}]}])

--- a/src/renderer/tool/impl/misc/fill.cljs
+++ b/src/renderer/tool/impl/misc/fill.cljs
@@ -4,6 +4,7 @@
    [renderer.action.events :as-alias action.events]
    [renderer.document.handlers :as document.handlers]
    [renderer.element.handlers :as element.handlers]
+   [renderer.hierarchy :as hierarchy]
    [renderer.history.handlers :as history.handlers]
    [renderer.i18n.views :as i18n.views]
    [renderer.tool.events :as-alias tool.events]
@@ -13,13 +14,13 @@
    [renderer.utils.element :as utils.element]
    [renderer.utils.key :as utils.key]))
 
-(tool.hierarchy/derive! :fill ::tool.hierarchy/tool)
+(hierarchy/derive! ::fill ::tool.hierarchy/tool)
 
-(defmethod tool.hierarchy/help [:fill :idle]
+(defmethod tool.hierarchy/help [::fill :idle]
   []
   (i18n.views/t [::help "Click on an element to fill."]))
 
-(defmethod tool.hierarchy/on-activate :fill
+(defmethod tool.hierarchy/on-activate ::fill
   [db]
   (tool.handlers/set-cursor db "crosshair"))
 
@@ -32,15 +33,15 @@
         (element.handlers/set-attr el-id :fill color)
         (history.handlers/finalize timestamp [::fill "Fill"]))))
 
-(defmethod tool.hierarchy/on-pointer-up [:fill :idle]
+(defmethod tool.hierarchy/on-pointer-up [::fill :idle]
   [db e]
   (fill db (:timestamp e)))
 
-(defmethod tool.hierarchy/on-drag-end [:fill :idle]
+(defmethod tool.hierarchy/on-drag-end [::fill :idle]
   [db e]
   (fill db (:timestamp e)))
 
-(defmethod tool.hierarchy/on-pointer-move [:fill :idle]
+(defmethod tool.hierarchy/on-pointer-move [::fill :idle]
   [db e]
   (let [color (document.handlers/attr db :fill)
         el (-> e :element)]
@@ -48,7 +49,7 @@
       (not (utils.element/root? el))
       (element.handlers/set-attr (:id el) :fill color))))
 
-(defmethod tool.hierarchy/on-pointer-down [:fill :idle]
+(defmethod tool.hierarchy/on-pointer-down [::fill :idle]
   [db e]
   (-> db
       (assoc :clicked-element (-> e :element))
@@ -58,6 +59,6 @@
               {:id :tool/fill
                :label [::label "Fill"]
                :icon "fill"
-               :event [::tool.events/activate :fill]
-               :active [::tool.subs/active? :fill]
+               :event [::tool.events/activate ::fill]
+               :active [::tool.subs/active? ::fill]
                :shortcuts [{:keyCode (utils.key/codes "F")}]}])

--- a/src/renderer/tool/impl/misc/guide.cljs
+++ b/src/renderer/tool/impl/misc/guide.cljs
@@ -5,6 +5,7 @@
    [renderer.action.events :as-alias action.events]
    [renderer.app.handlers :as app.handlers]
    [renderer.element.handlers :as element.handlers]
+   [renderer.hierarchy :as hierarchy]
    [renderer.history.handlers :as history.handlers]
    [renderer.i18n.views :as i18n.views]
    [renderer.input.handlers :as input.handlers]
@@ -13,7 +14,7 @@
    [renderer.tool.hierarchy :as tool.hierarchy]
    [renderer.tool.subs :as-alias tool.subs]))
 
-(tool.hierarchy/derive! :guide ::tool.hierarchy/tool)
+(hierarchy/derive! ::guide ::tool.hierarchy/tool)
 
 (defonce orient (reagent/atom nil))
 
@@ -28,30 +29,28 @@
     "ns-resize"
     "ew-resize"))
 
-(defmethod tool.hierarchy/help [:guide :idle]
+(defmethod tool.hierarchy/help [::guide :idle]
   []
   (i18n.views/t [::idle "Drag the ruler to the canvas to create a guide."]))
 
-(defmethod tool.hierarchy/help [:guide :create]
+(defmethod tool.hierarchy/help [::guide :create]
   []
   (i18n.views/t [::create "Drop to finalize the guide."]))
 
-(defmethod tool.hierarchy/on-activate :guide
+(defmethod tool.hierarchy/on-activate ::guide
   [db & {:as props}]
   (let [{:keys [orientation]} props
         orientation (or orientation @orient)]
-    (cond-> db
-      orientation
-      (-> (assoc :guides true)
+    (if
+     orientation
+      (-> db
+          (assoc :guides true)
           (assoc :guides-locked false)
           (tool.handlers/set-cursor (cursor orientation))
-          (app.handlers/add-fx [::set-orientation orientation])))))
+          (app.handlers/add-fx [::set-orientation orientation]))
+      (tool.handlers/deactivate db))))
 
-(defmethod tool.hierarchy/on-cancel :guide
-  [db]
-  (tool.handlers/activate db :transform))
-
-(defmethod tool.hierarchy/on-pointer-move [:guide :idle]
+(defmethod tool.hierarchy/on-pointer-move [::guide :idle]
   [db {:keys [pointer-id]
        :as e}]
   (-> db
@@ -59,14 +58,14 @@
       (assoc-in [:active-pointers pointer-id] e)
       (input.handlers/on-drag-start e)))
 
-(defmethod tool.hierarchy/on-pointer-move [:guide :create]
+(defmethod tool.hierarchy/on-pointer-move [::guide :create]
   [db _e]
   (let [[x y] (tool.handlers/snapped-position db)]
     (-> db
         (element.handlers/update-selected #(assoc-in % [:attrs :x] (str x)))
         (element.handlers/update-selected #(assoc-in % [:attrs :y] (str y))))))
 
-(defmethod tool.hierarchy/on-pointer-down [:guide :create]
+(defmethod tool.hierarchy/on-pointer-down [::guide :create]
   [db _e]
   (let [[x y] (tool.handlers/snapped-position db)]
     (element.handlers/add db {:type :element
@@ -75,7 +74,7 @@
                                       :y y
                                       :orientation (name @orient)}})))
 
-(defmethod tool.hierarchy/on-drag-start [:guide :idle]
+(defmethod tool.hierarchy/on-drag-start [::guide :idle]
   [db e]
   (-> db
       (tool.handlers/set-state :create)
@@ -85,23 +84,23 @@
   [db e]
   (-> db
       (history.handlers/finalize (:timestamp e) [::add-guide "Add guide"])
-      (tool.handlers/activate :transform)))
+      (tool.handlers/deactivate)))
 
-(defmethod tool.hierarchy/on-pointer-up [:guide :create]
+(defmethod tool.hierarchy/on-pointer-up [::guide :create]
   [db e]
   (finalize db e))
 
-(defmethod tool.hierarchy/on-drag-end [:guide :create]
+(defmethod tool.hierarchy/on-drag-end [::guide :create]
   [db e]
   (finalize db e))
 
-(defmethod tool.hierarchy/snapping-points [:guide :create]
+(defmethod tool.hierarchy/snapping-points [::guide :create]
   [db]
   [(with-meta
      (:adjusted-pointer-pos db)
      {:label [::guide-position "guide position"]})])
 
-(defmethod tool.hierarchy/snapping-elements [:guide :create]
+(defmethod tool.hierarchy/snapping-elements [::guide :create]
   [db]
   (element.handlers/visible db))
 
@@ -109,5 +108,5 @@
               {:id :tool/guide
                :label [::label "Guide"]
                :icon "ruler-straight"
-               :event [::tool.events/activate :guide]
-               :active [::tool.subs/active? :guide]}])
+               :event [::tool.events/activate ::guide]
+               :active [::tool.subs/active? ::guide]}])

--- a/src/renderer/tool/impl/misc/measure.cljs
+++ b/src/renderer/tool/impl/misc/measure.cljs
@@ -7,6 +7,7 @@
    [renderer.app.handlers :as app.handlers]
    [renderer.document.subs :as-alias document.subs]
    [renderer.element.handlers :as element.handlers]
+   [renderer.hierarchy :as hierarchy]
    [renderer.i18n.views :as i18n.views]
    [renderer.tool.events :as-alias tool.events]
    [renderer.tool.handlers :as tool.handlers]
@@ -17,7 +18,7 @@
    [renderer.utils.math :as utils.math]
    [renderer.utils.svg :as utils.svg]))
 
-(tool.hierarchy/derive! :measure ::tool.hierarchy/tool)
+(hierarchy/derive! ::measure ::tool.hierarchy/tool)
 
 (defonce measure-attrs (reagent/atom nil))
 
@@ -26,31 +27,31 @@
  (fn [value]
    (reset! measure-attrs value)))
 
-(defmethod tool.hierarchy/help [:measure :idle]
+(defmethod tool.hierarchy/help [::measure :idle]
   []
   (i18n.views/t [::click-and-drag "Click and drag to measure a distance."]))
 
-(defmethod tool.hierarchy/help [:measure :create]
+(defmethod tool.hierarchy/help [::measure :create]
   []
   (i18n.views/t [::release-to-finalize "Release to finalize the measurement."]))
 
-(defmethod tool.hierarchy/on-activate :measure
+(defmethod tool.hierarchy/on-activate ::measure
   [db]
   (tool.handlers/set-cursor db "crosshair"))
 
-(defmethod tool.hierarchy/on-deactivate :measure
+(defmethod tool.hierarchy/on-deactivate ::measure
   [db]
   (app.handlers/add-fx db [::set-measure-attrs nil]))
 
-(defmethod tool.hierarchy/on-drag-start [:measure :idle]
+(defmethod tool.hierarchy/on-drag-start [::measure :idle]
   [db _e]
   (tool.handlers/set-state db :create))
 
-(defmethod tool.hierarchy/on-drag-end [:measure :create]
+(defmethod tool.hierarchy/on-drag-end [::measure :create]
   [db _e]
   (tool.handlers/set-state db :idle))
 
-(defmethod tool.hierarchy/on-drag [:measure :create]
+(defmethod tool.hierarchy/on-drag [::measure :create]
   [db _e]
   (let [[offset-x offset-y] (tool.handlers/snapped-offset db)
         [x y] (tool.handlers/snapped-position db)
@@ -62,7 +63,7 @@
                                                   :y2 y
                                                   :hypotenuse hypotenuse}])))
 
-(defmethod tool.hierarchy/render :measure
+(defmethod tool.hierarchy/render ::measure
   []
   (when @measure-attrs
     (let [handle-size @(rf/subscribe [::document.subs/handle-size])
@@ -106,19 +107,19 @@
                [::measure-end "measure end"]
                [::measure-start "measure start"])})])
 
-(defmethod tool.hierarchy/snapping-points [:measure :idle]
+(defmethod tool.hierarchy/snapping-points [::measure :idle]
   [db]
   (snap-point db))
 
-(defmethod tool.hierarchy/snapping-points [:measure :create]
+(defmethod tool.hierarchy/snapping-points [::measure :create]
   [db]
   (snap-point db))
 
-(defmethod tool.hierarchy/snapping-elements [:measure :idle]
+(defmethod tool.hierarchy/snapping-elements [::measure :idle]
   [db]
   (element.handlers/visible db))
 
-(defmethod tool.hierarchy/snapping-elements [:measure :create]
+(defmethod tool.hierarchy/snapping-elements [::measure :create]
   [db]
   (element.handlers/visible db))
 
@@ -126,6 +127,6 @@
               {:id :tool/measure
                :label [::label "Measure"]
                :icon "ruler-triangle"
-               :event [::tool.events/activate :measure]
-               :active [::tool.subs/active? :measure]
+               :event [::tool.events/activate ::measure]
+               :active [::tool.subs/active? ::measure]
                :shortcuts [{:keyCode (utils.key/codes "M")}]}])

--- a/test/tool_test.cljs
+++ b/test/tool_test.cljs
@@ -7,6 +7,8 @@
    [renderer.element.events :as-alias element.events]
    [renderer.tool.events :as-alias tool.events]
    [renderer.tool.hierarchy :as tool.hierarchy]
+   [renderer.tool.impl.base.edit :as-alias tool.impl.base.edit]
+   [renderer.tool.impl.base.transform.core :as-alias tool.impl.base.transform]
    [renderer.tool.subs :as-alias tool.subs]))
 
 (deftest tool
@@ -16,20 +18,20 @@
    (let [active-tool (rf/subscribe [::tool.subs/active])]
 
      (testing "initial"
-       (is (= @active-tool :transform)))
+       (is (= @active-tool ::tool.impl.base.transform/transform)))
 
      (testing "edit tool"
-       (rf/dispatch [::tool.events/activate :edit])
-       (is (= @active-tool :edit))
-       (is (= (tool.hierarchy/render :edit) [:g]))
+       (rf/dispatch [::tool.events/activate ::tool.impl.base.edit/edit])
+       (is (= @active-tool ::tool.impl.base.edit/edit))
+       (is (= (tool.hierarchy/render ::tool.impl.base.edit/edit) [:g]))
 
        (rf/dispatch [::element.events/add {:tag :rect
                                            :attrs {:width 100
                                                    :height 100}}])
 
-       (rf/dispatch [::tool.events/activate :edit])
-       (is (not= (tool.hierarchy/render :edit) [:g])))
+       (rf/dispatch [::tool.events/activate ::tool.impl.base.edit/edit])
+       (is (not= (tool.hierarchy/render ::tool.impl.base.edit/edit) [:g])))
 
      (testing "cancel"
        (rf/dispatch [::tool.events/cancel])
-       (is (= @active-tool :transform))))))
+       (is (= @active-tool ::tool.impl.base.transform/transform))))))


### PR DESCRIPTION
We will now use main hierarchy atom for our tools. Using fully qualified keywords is required in order to avoid conflicts. We also reduced coupling between tools by introducing a `deactivate` and an `edit` tool method. Tools shouldn't have to be aware of the existence of other tools. The recently added `on-cancel` multi-method was removed, since it was only used by our guide tool, and can be replaced by a simple `deactivate`. The `poly` tool was using the active tool keyword to generate the proper tag. We now explicitly create a different element for polygons and polylines.